### PR TITLE
Add server host name to emails sent by DMI-TCAT

### DIFF
--- a/capture/common/functions.php
+++ b/capture/common/functions.php
@@ -386,7 +386,7 @@ function ratelimit_report_problem() {
         if ($row = mysql_fetch_assoc($result)) {
             if (isset($row['cnt']) && $row['cnt'] == 0) {
                 global $mail_to;
-                mail($mail_to, 'DMI-TCAT rate limit has been reached', 'The script running the ' . CAPTURE . ' query has hit a rate limit while talking to the Twitter API. Twitter is not allowing you to track more than 1% of its total traffic at any time. This means that the number of tweets exceeding the barrier are being dropped. Consider reducing the size of your query bins and reducing the number of terms and users you are tracking.' . "\n\n" .
+                mail($mail_to, 'DMI-TCAT rate limit has been reached (server: ' . getHostName() . ')', 'The script running the ' . CAPTURE . ' query has hit a rate limit while talking to the Twitter API. Twitter is not allowing you to track more than 1% of its total traffic at any time. This means that the number of tweets exceeding the barrier are being dropped. Consider reducing the size of your query bins and reducing the number of terms and users you are tracking.' . "\n\n" .
                         'This may be a temporary or a structural problem. Please look at the webinterface for more details. Rate limit statistics on the website are historic, however. Consider this message indicative of a current issue. This e-mail will not be repeated for at least ' . RATELIMIT_MAIL_HOURS . ' hours.', 'From: no-reply@dmitcat');
             }
         }

--- a/capture/stream/controller.php
+++ b/capture/stream/controller.php
@@ -147,7 +147,7 @@ foreach ($roles as $role) {
 
                 // notify user via email when we restart an idle script
                 if (!$reload && $idled && isset($mail_to) && trim($mail_to) != "")
-                    mail($mail_to, "DMI-TCAT controller killed a process", $restartmsg);
+                    mail($mail_to, "DMI-TCAT controller killed a process (server: " . getHostName() . ")" , $restartmsg, 'From: no-reply@dmitcat');
 
                 if (script_lock($role, true) === true) {
                     // restart script


### PR DESCRIPTION
With multiple servers it is difficult to tell which one the DMI-TCAT emails come from at the moment.