### PR TITLE
Multiple query bin export feature

### DIFF
--- a/analysis/common/config.php
+++ b/analysis/common/config.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once('../config.php');
+include_once(__DIR__ . '/../../config.php');
 
 /*
  * Whether to cache results

--- a/capture/query_manager.php
+++ b/capture/query_manager.php
@@ -1,12 +1,12 @@
 <?php
 
-include_once("../config.php");
+include_once(__DIR__ . "/../config.php");
 
 if (defined(ADMIN_USER) && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
     die("Go away, you evil hacker!");
 
-include_once("../common/functions.php");
-include_once("../capture/common/functions.php");
+include_once(__DIR__ . "/../common/functions.php");
+include_once(__DIR__ . "/../capture/common/functions.php");
 
 $captureroles = unserialize(CAPTUREROLES);
 $now = strftime("%Y-%m-%d %H:%M:00", date('U') + 60); // controller only called each minute

--- a/helpers/export.php
+++ b/helpers/export.php
@@ -39,7 +39,7 @@ function env_is_cli() {
     return (!isset($_SERVER['SERVER_SOFTWARE']) && (php_sapi_name() == 'cli' || (is_numeric($_SERVER['argc']) && $_SERVER['argc'] > 0)));
 }
 
-require_once(__DIR__ . "/../config.php");
+require_once(__DIR__ . '/../config.php');
 require_once(__DIR__ . '/../capture/query_manager.php');
 require_once(__DIR__ . '/../analysis/common/config.php');      /* to get global variable $resultsdir */
 require_once(__DIR__ . '/../common/functions.php');
@@ -90,10 +90,10 @@ for ($i = 1; $i < $argc; $i++) {
             echo "Usage: $prog [options] {queryBins...}\n";
             echo "Options:\n";
             echo "  -d       export query phrases AND data (default)\n";
-            echo "  -s       export query pharases only, with no data\n";
+            echo "  -s       export structure: query pharases only, no data\n";
             echo "  -o file  output file (default: automatically generated)\n";
             echo "  -h       show this help message\n";
-	    echo "If no queryBins are named, all the queryBins are exported.\n";
+	    echo "If no queryBins are named, all the query bins are exported.\n";
 	    echo "Default output file is a .sql.gz file in $defaultOutputDir\n";
 	    echo "Caution: query bin names are case sensitive.\n";
             exit(0);
@@ -214,6 +214,7 @@ foreach ($queryBins as $bin) {
 
 $bintype = getBinType($bin);
 if ($bintype === false) {
+    unlink($filename);
     die("$prog: error: unknown query bin: $bin\n");
 }
 
@@ -284,6 +285,7 @@ foreach ($tables as $table) {
 }
 
 if ($string == '') {
+    unlink($filename);
     die("$prog: internal error: could not find suitable tables for bin: $bin\n");
 }
 

--- a/helpers/export.php
+++ b/helpers/export.php
@@ -286,7 +286,7 @@ foreach ($tables as $table) {
 
 if ($string == '') {
     unlink($filename);
-    die("$prog: internal error: could not find suitable tables for bin: $bin\n");
+    die("$prog: internal error: no tables for bin: $bin (check case is correct)\n");
 }
 
 if ($export == "all") {

--- a/helpers/export.php
+++ b/helpers/export.php
@@ -34,23 +34,6 @@
 // 
 //     export.php -h
 // 
-// ## Old syntax
-// 
-// The old syntax (where there must be exactly two arguments: the query
-// bin and the export type) is still supported for backward compatibility.
-// 
-// Exports queries and data for the query bin "foobar":
-// 
-//    export.php foobar all
-// 
-// Exports queries only for the query bin "foobar":
-// 
-//    export.php foobar structure
-// 
-// Note: if exporting two query bins the name of the last/second query
-// bin cannot be "all" or "structure", otherwise it will be interepreted
-// as the export type instead of the name of a query bin.
-// 
 
 function env_is_cli() {
     return (!isset($_SERVER['SERVER_SOFTWARE']) && (php_sapi_name() == 'cli' || (is_numeric($_SERVER['argc']) && $_SERVER['argc'] > 0)));
@@ -119,23 +102,6 @@ for ($i = 1; $i < $argc; $i++) {
     }
 }
 
-if (2 <= count($args)) {
-    // Legacy command line format: treat last argument as exportType
-    switch ($args[count($args) - 1]) {
-        case "structure": {
-            $export = 'queries';
-            array_pop($args);
-            break;
-        }
-        case "all": {
-            $export = 'all';
-	    array_pop($args);
-            break;
-        }
-	// Default: ignore and treat last argument as a queryBin name
-    }
-}
-
 $queryBins = $args;
 
 // All query bins
@@ -152,7 +118,7 @@ if (count($queryBins) == 0) {
     sort($queryBins);
 } else {
 
-    // Check query bin names are vali
+    // Check query bin names are valid
     foreach ($queryBins as $bin) {
         $bintype = getBinType($queryBins[0]);
         if ($bintype === false) {

--- a/helpers/import.php
+++ b/helpers/import.php
@@ -5,7 +5,7 @@ function env_is_cli() {
     return (!isset($_SERVER['SERVER_SOFTWARE']) && (php_sapi_name() == 'cli' || (is_numeric($_SERVER['argc']) && $_SERVER['argc'] > 0)));
 }
 
-require_once("../config.php");
+require_once(__DIR__ . "/../config.php");
 
 require_once(BASE_FILE . '/capture/query_manager.php');
 require_once(BASE_FILE . '/analysis/common/config.php');      /* to get global variable $resultsdir */
@@ -96,3 +96,5 @@ function get_executable($binary) {
     }
     return $where;
 }
+
+?>

--- a/helpers/import.php
+++ b/helpers/import.php
@@ -11,12 +11,11 @@ function env_is_cli() {
     return (!isset($_SERVER['SERVER_SOFTWARE']) && (php_sapi_name() == 'cli' || (is_numeric($_SERVER['argc']) && $_SERVER['argc'] > 0)));
 }
 
-require_once(__DIR__ . "/../config.php");
-
-require_once(BASE_FILE . '/capture/query_manager.php');
-require_once(BASE_FILE . '/analysis/common/config.php');      /* to get global variable $resultsdir */
-require_once(BASE_FILE . '/common/functions.php');
-require_once(BASE_FILE . '/capture/common/functions.php');
+require_once(__DIR__ . '/../config.php');
+require_once(__DIR__ . '/../capture/query_manager.php');
+require_once(__DIR__ . '/../analysis/common/config.php');      /* to get global variable $resultsdir */
+require_once(__DIR__ . '/../common/functions.php');
+require_once(__DIR__ . '/../capture/common/functions.php');
 
 global $dbuser, $dbpass, $database, $hostname;
 

--- a/helpers/import.php
+++ b/helpers/import.php
@@ -1,5 +1,11 @@
 #!/usr/bin/php5
 <?php
+// DMI-TCAT import
+//
+// Imports query bins exported by the DMI-TCAT export.php script.
+//
+// Usage: import.php filename.sql.gz
+//
 
 function env_is_cli() {
     return (!isset($_SERVER['SERVER_SOFTWARE']) && (php_sapi_name() == 'cli' || (is_numeric($_SERVER['argc']) && $_SERVER['argc'] > 0)));
@@ -48,25 +54,36 @@ if (!is_readable($file)) {
 }
 
 $fh = gzopen("$file", "r") or die ("Cannot open gzipped '$file' for reading. Perhaps you are trying to open an uncompressed dump?\n");
-$bin = '';
+$queryBins = array();
 while ($line = fgets($fh)) {
     if (preg_match("/^-- Table structure for table `(.*)_tweets`/", $line, $matches)) {
-        $bin = $matches[1]; break;
+        array_push($queryBins, $matches[1]);
     }
     if (preg_match("/^INSERT INTO tcat_query_bins \( querybin, `type`, active, visible \) values \( '(.*?)',/", $line, $matches)) {
-        $bin = $matches[1]; break;
+        array_push($queryBins, $matches[1]);
     }
 }
 fclose($fh);
-if ($bin == '') {
+
+$queryBins = array_unique($queryBins);
+
+if (count($queryBins) == 0) {
     die("I did not recognize '$file' as a TCAT export.\n");
 }
 
-print "Recognized query bin '$bin'.\n";
+$binsExist = false;
+foreach ($queryBins as $bin) {
+    if (getBinType($bin) === false) {
+        print "Query bin: $bin\n";
+    } else {
+        print "Query bin already exists: $bin\n";
+        $binsExist = true;
+    }
+}
 
-$bintype = getBinType($bin);
-if ($bintype !== false) {
-    die("The query bin '$bin' already exists. Will not override. You may want to rename the existing query bin through the TCAT administration panel.\n");
+if ($binsExist) {
+    print "Error: query bin(s) already exist. Will not overwrite.\n";
+    die("You may want to rename the existing query bin through the TCAT administration panel.\n");
 }
 
 print "Now importing...\n";


### PR DESCRIPTION
This adds the capability to export multiple named query bins, as well as exporting all the query bins (without needing to explicitly name them all).

See discussion in DMI-TCAT [issue 143](https://github.com/digitalmethodsinitiative/dmi-tcat/issues/143).

Note: the main change is wrapping the original single-bin export code in a new `foreach` loop in _export.php_ from line 215 to 378. The indenting of the original code has not been changed so that it is easy to see what has not changed. After reviewing the changes, an extra level of indentation should be added to those lines.