### PR TITLE
Remove BASE_FILE and using __DIR__ instead

### DIFF
--- a/analysis/ajax.serverload.php
+++ b/analysis/ajax.serverload.php
@@ -1,6 +1,6 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
 
 /** configuration defaults **/
 if (!defined('TCAT_SYSLOAD_CHECKING')) {

--- a/analysis/common/Coword.class.php
+++ b/analysis/common/Coword.class.php
@@ -93,7 +93,7 @@ class Coword {
         arsort($this->words);
 
         // remove stop words
-        include_once(__DIR__ . '/common/Stopwords.class.php');
+        include_once __DIR__ . '/common/Stopwords.class.php';
         $sw = new Stopwords();
         $sw->loadAllLists();
         $cleaned = $sw->removeStopwords(array_keys($this->words));
@@ -288,7 +288,7 @@ class Coword {
     }
 
     function getCowordsAsGexf($title = "") {
-        include_once(__DIR__ . 'Gexf.class.php');
+        include_once __DIR__ . '/Gexf.class.php';
         $gexf = new Gexf();
         $gexf->setTitle("Co-word " . $title);
         $gexf->setEdgeType(GEXF_EDGE_UNDIRECTED);

--- a/analysis/common/Coword.class.php
+++ b/analysis/common/Coword.class.php
@@ -93,7 +93,7 @@ class Coword {
         arsort($this->words);
 
         // remove stop words
-        include_once('common/Stopwords.class.php');
+        include_once(__DIR__ . '/common/Stopwords.class.php');
         $sw = new Stopwords();
         $sw->loadAllLists();
         $cleaned = $sw->removeStopwords(array_keys($this->words));
@@ -288,7 +288,7 @@ class Coword {
     }
 
     function getCowordsAsGexf($title = "") {
-        include_once('Gexf.class.php');
+        include_once(__DIR__ . 'Gexf.class.php');
         $gexf = new Gexf();
         $gexf->setTitle("Co-word " . $title);
         $gexf->setEdgeType(GEXF_EDGE_UNDIRECTED);

--- a/analysis/common/functions.php
+++ b/analysis/common/functions.php
@@ -379,7 +379,7 @@ function groupByInterval($date) {
 function generate($what, $filename) {
     global $tsv, $network, $esc, $titles, $database, $interval, $outputformat;
 
-    require_once("CSV.class.php");
+    require_once __DIR__ . '/CSV.class.php';
 
     // initialize variables
     $tweets = $times = $from_user_names = $results = $urls = $urls_expanded = $hosts = $hashtags = array();

--- a/analysis/index.php
+++ b/analysis/index.php
@@ -1,7 +1,7 @@
 <?php
-require_once '../config.php';
-require_once 'common/config.php';
-require_once 'common/functions.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.berno.mention_graph.php
+++ b/analysis/mod.berno.mention_graph.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once './common/config.php';
-require_once './common/functions.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
 
 // TODO: test Follower vs. Friend Metrics
 

--- a/analysis/mod.cascade.php
+++ b/analysis/mod.cascade.php
@@ -1,7 +1,7 @@
 <?php
 // @todo order by date
-require_once './common/config.php';
-require_once './common/functions.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
 
 validate_all_variables();
 $collation = current_collation();

--- a/analysis/mod.export_hashtags.php
+++ b/analysis/mod.export_hashtags.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.export_mentions.php
+++ b/analysis/mod.export_mentions.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 
 ?>
 

--- a/analysis/mod.export_tweet_ids.php
+++ b/analysis/mod.export_tweet_ids.php
@@ -1,6 +1,6 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.export_tweets.php
+++ b/analysis/mod.export_tweets.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.export_tweets_lang.php
+++ b/analysis/mod.export_tweets_lang.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.export_tweets_sentiment.php
+++ b/analysis/mod.export_tweets_sentiment.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.export_urls.php
+++ b/analysis/mod.export_urls.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.hashtag_cooc.php
+++ b/analysis/mod.hashtag_cooc.php
@@ -1,6 +1,6 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
 
 $variability = false;       // @todo used as hack for experiment in first issue mapping workshop
 $uselocalresults = false;   // @todo used as hack for experiment in first issue mapping workshop
@@ -30,7 +30,7 @@ $uselocalresults = false;   // @todo used as hack for experiment in first issue 
         if (empty($esc['shell']['topu']))
             $esc['shell']['topu'] = 0;
 
-        include_once('common/Coword.class.php');
+        include_once(__DIR__ . '/common/Coword.class.php');
         $coword = new Coword;
         $coword->countWordOncePerDocument = FALSE;
 

--- a/analysis/mod.hashtag_cooc_sentiment.php
+++ b/analysis/mod.hashtag_cooc_sentiment.php
@@ -1,6 +1,6 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
 
 $variability = false;       // @todo used as hack for experiment in first issue mapping workshop
 $uselocalresults = false;   // @todo used as hack for experiment in first issue mapping workshop
@@ -28,7 +28,7 @@ $uselocalresults = false;   // @todo used as hack for experiment in first issue 
         if (empty($esc['shell']['minf']))
             $esc['shell']['minf'] = 4;
 
-        include_once('common/Coword.class.php');
+        include_once __DIR__ . '/common/Coword.class.php';
         $coword = new Coword;
         $coword->countWordOncePerDocument = FALSE;
 

--- a/analysis/mod.hashtag_user.php
+++ b/analysis/mod.hashtag_user.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Gexf.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Gexf.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -25,7 +25,7 @@ require_once './common/Gexf.class.php';
 
         $filename = get_filename_for_export("hashtagUser", (isset($_GET['probabilityOfAssociation']) ? "_normalizedAssociationWeight" : ""), "gexf");
 
-        include_once('common/Coword.class.php');
+        include_once __DIR__ . '/common/Coword.class.php';
         $coword = new Coword;
         $coword->countWordOncePerDocument = FALSE;
 

--- a/analysis/mod.hashtag_user_activity.php
+++ b/analysis/mod.hashtag_user_activity.php
@@ -1,8 +1,8 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Gexf.class.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Gexf.class.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.hashtag_variability.php
+++ b/analysis/mod.hashtag_variability.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Coword.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Coword.class.php';
 validate_all_variables();
 ?>
 
@@ -519,7 +519,7 @@ validate_all_variables();
                                                             }
 
                                                             function getGEXFtimeseries($filename, $series) {
-                                                                include_once('common/Gexf.class.php');
+                                                                include_once(__DIR__ . '/common/Gexf.class.php');
                                                                 $gexf = new Gexf();
                                                                 $gexf->setTitle("Co-word " . $filename);
                                                                 $gexf->setEdgeType(GEXF_EDGE_UNDIRECTED);

--- a/analysis/mod.hosts_hashtags.php
+++ b/analysis/mod.hosts_hashtags.php
@@ -1,8 +1,8 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Gexf.class.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Gexf.class.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.interaction_graph.php
+++ b/analysis/mod.interaction_graph.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Gexf.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Gexf.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.lang_hashtags.php
+++ b/analysis/mod.lang_hashtags.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Gexf.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Gexf.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.media_frequency.php
+++ b/analysis/mod.media_frequency.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 
 $minf = isset($_GET['minf']) ? $minf = $_GET['minf'] : 1;
 

--- a/analysis/mod.mention_graph.php
+++ b/analysis/mod.mention_graph.php
@@ -1,6 +1,6 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.mention_graph_sentiment.php
+++ b/analysis/mod.mention_graph_sentiment.php
@@ -1,6 +1,6 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.mention_hashtags.php
+++ b/analysis/mod.mention_hashtags.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Gexf.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Gexf.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.retweet_urls.php
+++ b/analysis/mod.retweet_urls.php
@@ -1,6 +1,6 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.retweets_chain.php
+++ b/analysis/mod.retweets_chain.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.sankeymaker.php
+++ b/analysis/mod.sankeymaker.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Gexf.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Gexf.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.sentiment_cloud.php
+++ b/analysis/mod.sentiment_cloud.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.sources.stats.php
+++ b/analysis/mod.sources.stats.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.sources.stats.wip.php
+++ b/analysis/mod.sources.stats.wip.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.sources_hashtags.php
+++ b/analysis/mod.sources_hashtags.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Gexf.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Gexf.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.trending.php
+++ b/analysis/mod.trending.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once '../config.separate.php';
-require_once './common/functions.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/../config.separate.php';
+require_once __DIR__ . '/common/functions.php';
 
 $bootstrap = 14;
 if (isset($_GET['bootstrap']))

--- a/analysis/mod.tweet.stats.php
+++ b/analysis/mod.tweet.stats.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.url_hashtags.php
+++ b/analysis/mod.url_hashtags.php
@@ -1,8 +1,8 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Gexf.class.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Gexf.class.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.url_user.php
+++ b/analysis/mod.url_user.php
@@ -1,8 +1,8 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Gexf.class.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Gexf.class.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.user.list.php
+++ b/analysis/mod.user.list.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.user.stats.php
+++ b/analysis/mod.user.stats.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php'
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php'
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/analysis/mod.word_frequency.php
+++ b/analysis/mod.word_frequency.php
@@ -1,6 +1,6 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
 
 $lowercase = isset($_GET['lowercase']) ? $lowercase = $_GET['lowercase'] : 0;
 $minf = isset($_GET['minf']) ? $minf = $_GET['minf'] : 1;

--- a/analysis/mod.word_list.php
+++ b/analysis/mod.word_list.php
@@ -1,7 +1,7 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/CSV.class.php';
 
 $lowercase = isset($_GET['lowercase']) ? $lowercase = $_GET['lowercase'] : 0;
 $minf = isset($_GET['minf']) ? $minf = $_GET['minf'] : 1;

--- a/analysis/mod.word_variability.php
+++ b/analysis/mod.word_variability.php
@@ -1,8 +1,8 @@
 <?php
-require_once './common/config.php';
-require_once './common/functions.php';
-require_once './common/Coword.class.php';
-require_once './common/CSV.class.php';
+require_once __DIR__ . '/common/config.php';
+require_once __DIR__ . '/common/functions.php';
+require_once __DIR__ . '/common/Coword.class.php';
+require_once __DIR__ . '/common/CSV.class.php';
 validate_all_variables();
 $collation = current_collation();
 $method = "word";
@@ -571,7 +571,7 @@ $method = "word";
 
                                                                 function getGEXFtimeseries($filename, $series) {
 // time-series gexf
-                                                                    include_once('common/Gexf.class.php');
+                                                                    include_once(__DIR__ . '/common/Gexf.class.php');
                                                                     $gexf = new Gexf();
                                                                     $gexf->setTitle("Co-word " . $filename);
                                                                     $gexf->setEdgeType(GEXF_EDGE_UNDIRECTED);

--- a/capture/common/form.trackgeophrases.php
+++ b/capture/common/form.trackgeophrases.php
@@ -1,5 +1,5 @@
 <?php
-include_once("../../config.php");
+include_once __DIR__ . '/../../config.php';
 
 if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
     die("Go away, you evil hacker!");

--- a/capture/common/form.trackphrases.php
+++ b/capture/common/form.trackphrases.php
@@ -1,5 +1,5 @@
 <?php
-include_once("../../config.php");
+include_once __DIR__ . '/../../config.php';
 
 if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
     die("Go away, you evil hacker!");

--- a/capture/common/functions.php
+++ b/capture/common/functions.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once("geoPHP/geoPHP.inc"); // geoPHP library
+require_once __DIR__ . '/geoPHP/geoPHP.inc'; // geoPHP library
 
 error_reporting(E_ALL);
 ini_set("max_execution_time", 0);       // capture script want unlimited execution time
@@ -438,7 +438,7 @@ function tcat_autoupgrade() {
  */
 
 function script_lock($script, $test = false) {
-    $lockfile = BASE_FILE . "proc/$script.lock";
+    $lockfile = __DIR__ . "/../../proc/$script.lock";
 
     if (!file_exists($lockfile)) {
         touch($lockfile);
@@ -467,20 +467,20 @@ function logit($file, $message) {
     if ($file == "cli")
         print $message;
     else
-        file_put_contents(BASE_FILE . "logs/" . $file, $message, FILE_APPEND);
+        file_put_contents(__DIR__ . "/../../logs/" . $file, $message, FILE_APPEND);
 }
 
 /*
  * Returns the git status information for the local install
  */
 function getGitLocal() {
-    $gitcmd = 'git --git-dir ' . BASE_FILE . '.git log --pretty=oneline -n 1';
+    $gitcmd = 'git --git-dir ' . realpath(__DIR__ . '/../..') .  '/.git log --pretty=oneline -n 1';
     $gitlog = `$gitcmd`;
     $parse = rtrim($gitlog);
     if (preg_match("/^([a-z0-9]+)[\t ](.+)$/", $parse, $matches)) {
         $commit = $matches[1];
         $mesg = $matches[2];
-        $gitcmd = 'git --git-dir ' . BASE_FILE . '.git rev-parse --abbrev-ref HEAD';
+        $gitcmd = 'git --git-dir ' . realpath(__DIR__ . '/../..') . '/.git rev-parse --abbrev-ref HEAD';
         $gitrev = `$gitcmd`;
         $branch = rtrim($gitrev);
         return array( 'branch' => $branch,
@@ -1620,7 +1620,7 @@ class TweetQueue {
 
             if (defined('CAPTURE') && database_activity($dbh)) {
                 $pid = getmypid();
-                file_put_contents(BASE_FILE . "proc/" . CAPTURE . ".procinfo", $pid . "|" . time());
+                file_put_contents(__DIR__ . "/../../proc/" . CAPTURE . ".procinfo", $pid . "|" . time());
             }
         }
 
@@ -1808,7 +1808,7 @@ function tracker_run() {
     logit(CAPTURE . ".error.log", "started script " . CAPTURE . " with pid $pid");
 
     $lastinsert = time();
-    $procfilename = BASE_FILE . "proc/" . CAPTURE . ".procinfo";
+    $procfilename = __DIR__ . "/../../proc/" . CAPTURE . ".procinfo";
     if (file_put_contents($procfilename, $pid . "|" . time()) === FALSE) {
         logit(CAPTURE . ".error.log", "cannot register capture script start time (file \"$procfilename\" is not WRITABLE. make sure the proc/ directory exists in your webroot and is writable by the cron user)");
         die();

--- a/capture/ids/lookup.php
+++ b/capture/ids/lookup.php
@@ -5,11 +5,11 @@ if ($argc < 1)
 // ----- params -----
 set_time_limit(0);
 error_reporting(E_ALL);
-include_once "../../config.php";
-include_once BASE_FILE . '/common/functions.php';
-include_once BASE_FILE . '/capture/common/functions.php';
+include_once __DIR__ . '/../../config.php';
+include_once __DIR__ . '/../../common/functions.php';
+include_once __DIR__ . '/../../capture/common/functions.php';
 
-require BASE_FILE . 'capture/common/tmhOAuth/tmhOAuth.php';
+require __DIR__ . '/../../capture/common/tmhOAuth/tmhOAuth.php';
 
 
 // DEFINE LOOKUP PARAMETERS HERE

--- a/capture/index.php
+++ b/capture/index.php
@@ -1,13 +1,13 @@
 <?php
-include_once("../config.php");
+include_once __DIR__ . '/../config.php';
 
 if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
     die("Go away, you evil hacker!");
 
-include_once("query_manager.php");
-include_once BASE_FILE . '/common/functions.php';
-include_once BASE_FILE . '/common/upgrade.php';
-include_once BASE_FILE . '/capture/common/functions.php';
+include_once __DIR__ . '/query_manager.php';
+include_once __DIR__ . '/../common/functions.php';
+include_once __DIR__ . '/../common/upgrade.php';
+include_once __DIR__ . '/../capture/common/functions.php';
 
 create_admin();
 create_error_logs();

--- a/capture/klout/capture.php
+++ b/capture/klout/capture.php
@@ -4,9 +4,9 @@
 if ($argc < 1)
     die;
 
-require_once '../../config.php';
-require_once BASE_FILE . 'analysis/common/functions.php';
-require_once 'KloutAPIv2-PHP/KloutAPIv2.class.php';
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../analysis/common/functions.php';
+require_once __DIR__ . 'KloutAPIv2-PHP/KloutAPIv2.class.php';
 
 while (1) {
 

--- a/capture/klout/capture.php
+++ b/capture/klout/capture.php
@@ -6,7 +6,7 @@ if ($argc < 1)
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../analysis/common/functions.php';
-require_once __DIR__ . 'KloutAPIv2-PHP/KloutAPIv2.class.php';
+require_once __DIR__ . '/KloutAPIv2-PHP/KloutAPIv2.class.php';
 
 while (1) {
 

--- a/capture/public/form.trackgeophrases.php
+++ b/capture/public/form.trackgeophrases.php
@@ -1,5 +1,5 @@
 <?php
-include_once("../../config.php");
+include_once __DIR__ . '/../../config.php';
 
 if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
     die("Go away, you evil hacker!");

--- a/capture/public/form.trackphrases.php
+++ b/capture/public/form.trackphrases.php
@@ -1,5 +1,5 @@
 <?php
-include_once("../../config.php");
+include_once __DIR__ . '/../../config.php';
 
 if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
     die("Go away, you evil hacker!");

--- a/capture/query_manager.php
+++ b/capture/query_manager.php
@@ -1,12 +1,12 @@
 <?php
 
-include_once(__DIR__ . "/../config.php");
+include_once __DIR__ . '/../config.php';
 
 if (defined(ADMIN_USER) && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
     die("Go away, you evil hacker!");
 
-include_once(__DIR__ . "/../common/functions.php");
-include_once(__DIR__ . "/../capture/common/functions.php");
+include_once __DIR__ . '/../common/functions.php';
+include_once __DIR__ . '/../capture/common/functions.php';
 
 $captureroles = unserialize(CAPTUREROLES);
 $now = strftime("%Y-%m-%d %H:%M:00", date('U') + 60); // controller only called each minute

--- a/capture/search/search.php
+++ b/capture/search/search.php
@@ -5,11 +5,11 @@ if ($argc < 1)
 // ----- params -----
 set_time_limit(0);
 error_reporting(E_ALL);
-include_once "../../config.php";
-include_once BASE_FILE . '/common/functions.php';
-include_once BASE_FILE . '/capture/common/functions.php';
+include_once __DIR__ . '/../../config.php';
+include_once __DIR__ . '/../../common/functions.php';
+include_once __DIR__ . '/../../capture/common/functions.php';
 
-require BASE_FILE . 'capture/common/tmhOAuth/tmhOAuth.php';
+require __DIR__ . '/../../capture/common/tmhOAuth/tmhOAuth.php';
 
 // make sure only one search script is running
 $thislockfp = script_lock('search');

--- a/capture/stream/controller.php
+++ b/capture/stream/controller.php
@@ -8,7 +8,7 @@ function env_is_cli() {
 if (!env_is_cli())
     die;
 
-include_once __DIR__ . '../../config.php';
+include_once __DIR__ . '/../../config.php';
 include __DIR__ . '/../../common/functions.php';
 include __DIR__ . '/../common/functions.php';
 

--- a/capture/stream/controller.php
+++ b/capture/stream/controller.php
@@ -8,9 +8,9 @@ function env_is_cli() {
 if (!env_is_cli())
     die;
 
-include_once("../../config.php");
-include "../../common/functions.php";
-include "../common/functions.php";
+include_once __DIR__ . '../../config.php';
+include __DIR__ . '/../../common/functions.php';
+include __DIR__ . '/../common/functions.php';
 
 // make sure only one controller script is running
 $thislockfp = script_lock('controller');
@@ -92,7 +92,7 @@ if (AUTOUPDATE_ENABLED && $upgrade_requested == false) {
     }
     if ($failure == false) {
         // additionally we want to ensure only a single auto-update attempt is made per day
-        $nomodifyfile = BASE_FILE . 'nomodify.txt';
+        $nomodifyfile = __DIR__ . '/../../nomodify.txt';
         if (!file_exists($nomodifyfile)) {
             // the nomodify file does not seem to exist
             logit("controller.log", "auto-update not supported, because the nomodify.txt file appears to be missing");
@@ -114,12 +114,12 @@ if (AUTOUPDATE_ENABLED && $upgrade_requested == false) {
 }
 if ($upgrade_requested) {
     // git pull
-    if (!is_writable(BASE_FILE . "capture")) {
+    if (!is_writable(__DIR__ . '/../../capture')) {
         logit("controller.log", "auto-update requested, but the cron user does not have the neccessary permissions to do a successful git pull");
         $skipupdate = true;
     } else {
         logit("controller.log", "now attempting auto-update with: git pull");
-        chdir(BASE_FILE);
+        chdir(__DIR__ . '/../..');
         system("git pull 2>&1 >/dev/null", $status);
         if ($status !== 0) {
             logit("controller.log", "auto-update was not successful. The command 'git pull' seems to have failed. Did you make any local TCAT modifications? Please investigate manually.");
@@ -128,7 +128,7 @@ if ($upgrade_requested) {
     }
     // run upgrade.php
     logit("controller.log", "now attempting database auto-update by running: php upgrade.php");
-    chdir(BASE_FILE . "common");
+    chdir(__DIR__ . '/../../common');
     $flag = '--au0';
     if (AUTOUPDATE_LEVEL == 'substantial') {
         $flag = '--au1';
@@ -138,7 +138,7 @@ if ($upgrade_requested) {
     system("nohup php upgrade.php --non-interactive $flag", $status);
 }
 
-chdir(BASE_FILE . "capture/stream");
+chdir(__DIR__);
 
 // now check for each capture role what needs to be done
 foreach ($roles as $role) {
@@ -167,9 +167,9 @@ foreach ($roles as $role) {
     $pid = 0;
     $last = 0;
     $running = false;
-    if (file_exists(BASE_FILE . "proc/$role.procinfo")) {
+    if (file_exists(__DIR__ . '/../../proc/$role.procinfo')) {
 
-        $procfile = read_procfile(BASE_FILE . "proc/$role.procinfo");
+        $procfile = read_procfile(__DIR__ . "/../../proc/$role.procinfo");
         $pid = $procfile['pid'];
         $last = $procfile['last'];
 	    if ($pid == -1) exit();
@@ -243,7 +243,7 @@ foreach ($roles as $role) {
 
                     // a forked process may inherit our lock, but we prevent this.
                     flock($thislockfp, LOCK_UN); fclose($thislockfp);
-                    passthru(PHP_CLI . " " . BASE_FILE . "capture/stream/dmitcat_$role.php > /dev/null 2>&1 &");
+                    passthru(PHP_CLI . " " . __DIR__ . "/dmitcat_$role.php > /dev/null 2>&1 &");
                     $thislockfp = script_lock('controller');
                 }
             }
@@ -261,7 +261,7 @@ foreach ($roles as $role) {
 
             // a forked process may inherit our lock, but we prevent this.
             flock($thislockfp, LOCK_UN); fclose($thislockfp);
-            passthru(PHP_CLI . " " . BASE_FILE . "capture/stream/dmitcat_$role.php > /dev/null 2>&1 &");
+            passthru(PHP_CLI . " " . __DIR__ . "/dmitcat_$role.php > /dev/null 2>&1 &");
             $thislockfp = script_lock('controller');
         }
     }

--- a/capture/stream/dmitcat_follow.php
+++ b/capture/stream/dmitcat_follow.php
@@ -15,11 +15,11 @@ error_reporting(E_ALL);
 define('CAPTURE', 'follow');
 
 // ----- includes -----
-include "../../config.php";                  // load base config file
-include "../../common/functions.php";        // load base functions file
-include "../common/functions.php";           // load capture function file
+include __DIR__ . '/../../config.php';                  // load base config file
+include __DIR__ . '/../../common/functions.php';        // load base functions file
+include __DIR__ . '/../common/functions.php';           // load capture function file
 
-require BASE_FILE . 'capture/common/tmhOAuth/tmhOAuth.php';
+require __DIR__ . '/../common/tmhOAuth/tmhOAuth.php';
 
 $thislockfp = script_lock(CAPTURE);
 if (!is_resource($thislockfp)) {

--- a/capture/stream/dmitcat_onepercent.php
+++ b/capture/stream/dmitcat_onepercent.php
@@ -15,11 +15,11 @@ error_reporting(E_ALL);
 define('CAPTURE', 'onepercent');
 
 // ----- includes -----
-include "../../config.php";                  // load base config file
-include "../../common/functions.php";        // load base functions file
-include "../common/functions.php";           // load capture function file
+include __DIR__ . '/../../config.php';                  // load base config file
+include __DIR__ . '/../../common/functions.php';        // load base functions file
+include __DIR__ . '/../common/functions.php";           // load capture function file
 
-require BASE_FILE . 'capture/common/tmhOAuth/tmhOAuth.php';
+require __DIR__ . '/../common/tmhOAuth/tmhOAuth.php';
 
 $thislockfp = script_lock(CAPTURE);
 if (!is_resource($thislockfp)) {

--- a/capture/stream/dmitcat_track.php
+++ b/capture/stream/dmitcat_track.php
@@ -15,11 +15,11 @@ error_reporting(E_ALL);
 define('CAPTURE', 'track');
 
 // ----- includes -----
-include "../../config.php";                  // load base config file
-include "../../common/functions.php";        // load base functions file
-include "../common/functions.php";           // load capture function file
+include __DIR__ . '/../../config.php';                  // load base config file
+include __DIR__ . '/../../common/functions.php';        // load base functions file
+include __DIR__ . '/../common/functions.php';           // load capture function file
 
-require BASE_FILE . 'capture/common/tmhOAuth/tmhOAuth.php';
+require __DIR__ . '/../common/tmhOAuth/tmhOAuth.php';
 
 $thislockfp = script_lock(CAPTURE);
 if (!is_resource($thislockfp)) {

--- a/capture/user/timeline.php
+++ b/capture/user/timeline.php
@@ -5,11 +5,11 @@ if ($argc < 1)
 // ----- params -----
 set_time_limit(0);
 error_reporting(E_ALL);
-include_once "../../config.php";
-include_once BASE_FILE . '/common/functions.php';
-include_once BASE_FILE . '/capture/common/functions.php';
+include_once __DIR__ . '/../../config.php';
+include_once __DIR__ . '/../../common/functions.php';
+include_once __DIR__ . '/../common/functions.php';
 
-require BASE_FILE . 'capture/common/tmhOAuth/tmhOAuth.php';
+require __DIR__ . '/../common/tmhOAuth/tmhOAuth.php';
 // ----- connection -----
 $dbh = pdo_connect();
 

--- a/capture/user/user-friends.php
+++ b/capture/user/user-friends.php
@@ -7,11 +7,11 @@ if ($argc < 1)
 // ----- params -----
 set_time_limit(0);
 error_reporting(E_ALL);
-include_once "../../config.php";
-include_once BASE_FILE . '/common/functions.php';
-include_once BASE_FILE . '/capture/common/functions.php';
+include_once __DIR__ . '/../../config.php';
+include_once __DIR__ . '/../../common/functions.php';
+include_once __DIR__ . '/../common/functions.php';
 
-require BASE_FILE . '/capture/common/tmhOAuth/tmhOAuth.php';
+require __DIR__ . '/../common/tmhOAuth/tmhOAuth.php';
 
 // ----- connection -----
 $dbh = pdo_connect();

--- a/common/upgrade-media.php
+++ b/common/upgrade-media.php
@@ -6,10 +6,10 @@ if ($argc < 1)
 set_time_limit(0);
 error_reporting(E_ALL);
 
-include_once("../config.php");
-include "functions.php";
-include "../capture/common/functions.php";
-include "../capture/common/tmhOAuth/tmhOAuth.php";
+include_once __DIR__ . '/../config.php';
+include __DIR__ . '/functions.php';
+include __DIR__ . '/../capture/common/functions.php';
+include __DIR__ . '/../capture/common/tmhOAuth/tmhOAuth.php';
 
 if (dbserver_has_utf8mb4_support() == false) {
     die("DMI-TCAT requires at least MySQL version 5.5.3 - please upgrade your server\n");

--- a/common/upgrade.php
+++ b/common/upgrade.php
@@ -23,9 +23,9 @@ function env_is_cli() {
 }
 
 if (env_is_cli()) {
-    include_once("../config.php");
-    include "functions.php";
-    include "../capture/common/functions.php";
+    include_once __DIR__ . '/../config.php';
+    include __DIR__ . '/functions.php';
+    include __DIR__ . '/../capture/common/functions.php';
 }
 
 function get_all_bins() {

--- a/config.php.example
+++ b/config.php.example
@@ -97,11 +97,6 @@ if (!defined('CAPTURE') || !strcmp(CAPTURE, "track")) {
 $kloutapi_key = "";
 
 /*
- * file root in which dmi-tcat resides
- */
-define('BASE_FILE', '/var/www/dmi-tcat/');
-
-/*
  * URL root in which dmi-tcats resides
  */
 define('BASE_URL', 'http://example.com/dmi-tcat/');

--- a/helpers/export.php
+++ b/helpers/export.php
@@ -39,11 +39,11 @@ function env_is_cli() {
     return (!isset($_SERVER['SERVER_SOFTWARE']) && (php_sapi_name() == 'cli' || (is_numeric($_SERVER['argc']) && $_SERVER['argc'] > 0)));
 }
 
-require_once(__DIR__ . '/../config.php');
-require_once(__DIR__ . '/../capture/query_manager.php');
-require_once(__DIR__ . '/../analysis/common/config.php');      /* to get global variable $resultsdir */
-require_once(__DIR__ . '/../common/functions.php');
-require_once(__DIR__ . '/../capture/common/functions.php');
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../capture/query_manager.php';
+require_once __DIR__ . '/../analysis/common/config.php';      /* to get global variable $resultsdir */
+require_once __DIR__ . '/../common/functions.php';
+require_once __DIR__ . '/../capture/common/functions.php';
 
 global $dbuser, $dbpass, $database, $hostname;
 

--- a/helpers/import.php
+++ b/helpers/import.php
@@ -11,11 +11,11 @@ function env_is_cli() {
     return (!isset($_SERVER['SERVER_SOFTWARE']) && (php_sapi_name() == 'cli' || (is_numeric($_SERVER['argc']) && $_SERVER['argc'] > 0)));
 }
 
-require_once(__DIR__ . '/../config.php');
-require_once(__DIR__ . '/../capture/query_manager.php');
-require_once(__DIR__ . '/../analysis/common/config.php');      /* to get global variable $resultsdir */
-require_once(__DIR__ . '/../common/functions.php');
-require_once(__DIR__ . '/../capture/common/functions.php');
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../capture/query_manager.php';
+require_once __DIR__ . '/../analysis/common/config.php';      /* to get global variable $resultsdir */
+require_once __DIR__ . '/../common/functions.php';
+require_once __DIR__ . '/../capture/common/functions.php';
 
 global $dbuser, $dbpass, $database, $hostname;
 

--- a/helpers/media-save.php
+++ b/helpers/media-save.php
@@ -14,8 +14,8 @@
  * $ php media-save.php bin_name /my/tmp/dir
  *
  */
-require_once('../config.php');
-require_once('../capture/common/functions.php');
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../capture/common/functions.php';
 
 $base_imgpath = '/tmp';
 

--- a/helpers/migrate.php
+++ b/helpers/migrate.php
@@ -18,9 +18,9 @@
 if ($argc < 1)
     exit(); // only run from command line
 
-require_once('../config.php');
-require_once('../common/functions.php');
-require_once('../capture/common/functions.php');
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../common/functions.php';
+require_once __DIR__ . '/../capture/common/functions.php';
 
 print "Were you running DMI-TCAT before the query manager was implemented (6 March 2014)? (yes/no)" . PHP_EOL;
 $ans = trim(fgets(fopen("php://stdin", "r")));
@@ -214,21 +214,21 @@ function querybinsPhpToDb() {
     create_admin();
     if (file_exists('../querybins.php')) {
         print "importing from querybins.php" . PHP_EOL;
-        include('../querybins.php');
+        include __DIR__ . '/../querybins.php';
         if (isset($querybins))
             binsToDb($querybins, 'track');
         $querybins = false;
     }
     if (file_exists('../followbins.php')) {
         print "importing from followbins.php" . PHP_EOL;
-        include('../followbins.php');
+        include __DIR__ . '/../followbins.php';
         if (isset($querybins))
             binsToDb($querybins, 'follow');
         $querybins = false;
     }
     if (file_exists('../querybins.php')) {
         print "importing query archives" . PHP_EOL;
-        include('../querybins.php');
+        include __DIR__ . '/../querybins.php';
         if (isset($queryarchives))
             binsToDb($queryarchives, 'track');
     }

--- a/helpers/tcat-install-linux.sh
+++ b/helpers/tcat-install-linux.sh
@@ -1064,11 +1064,6 @@ CFG="$TCAT_DIR/config.php"
 
 cp "$TCAT_DIR/config.php.example" "$CFG"
 
-VAR=BASE_FILE
-sed -i "s/^define('$VAR',[^)]*);/define('$VAR', __DIR__ . '\/');/g" "$CFG"
-# Note: some PHP files requires BASE_FILE to ends with a slash, but some don't
-# TODO: PHP code should be changed to just use __DIR__ and not need BASE_FILE
-
 VAR=ADMIN_USER
 VALUE="'$TCATADMINUSER'"
 sed -i "s/^define('$VAR',[^)]*);/define('$VAR', $VALUE);/g" "$CFG"

--- a/helpers/tcat-install-linux.sh
+++ b/helpers/tcat-install-linux.sh
@@ -240,7 +240,7 @@ promptPassword() {
 #----------------------------------------------------------------
 # Process command line
 
-SHORT_OPTS="bc:Ghls:U"
+SHORT_OPTS="bc:DGhls:U"
 if ! getopt $SHORT_OPTS "$@" >/dev/null; then
     echo "$PROG: usage error (use -h for help)" >&2
     exit 2
@@ -256,12 +256,14 @@ GEO_SEARCH=y
 CMD_SERVERNAME=
 DO_UPDATE_UPGRADE=y
 DO_SAVE_TCAT_LOGINS=
+DEBUG_MODE=
 HELP=
 
 while [ $# -gt 0 ]; do
     case "$1" in
         -b) BATCH_MODE=y;;
 	-c) CONFIG_FILE="$2"; shift;;
+        -D) DEBUG_MODE=y;; # undocumented option for testing
 	-G) GEO_SEARCH=n;;
 	-l) DO_SAVE_TCAT_LOGINS=y;;
         -s) CMD_SERVERNAME="$2"; shift;;
@@ -951,9 +953,35 @@ echo ""
 
 apt-get -qq install -y git
 
-# Create a shallow clone of the DMI-TCAT repository. Can be changed
-# later with "git-fetch --depth", or restore full history with --unshallow.
-git clone --depth 1 https://github.com/digitalmethodsinitiative/dmi-tcat.git "$TCAT_DIR"
+# Release of DMI-TCAT to use
+
+TCAT_GIT_REPOSITORY=https://github.com/digitalmethodsinitiative/dmi-tcat.git
+TCAT_GIT_BRANCH=master
+
+# To deploy a differnt branch or tagged release, change the above two variables
+# e.g. testing change from BASE_FILE to __DIR__: run in debug mode
+if [ "$DEBUG_MODE" = 'y' ]; then
+    TCAT_GIT_REPOSITORY=https://github.com/hoylen/dmi-tcat.git
+    TCAT_GIT_BRANCH=BASE_FILE
+fi
+
+if [ "$TCAT_GIT_BRANCH" == 'master' ]; then
+    # Can do a shallow clone to minimize the data download
+    # Can be changed later with "git fetch --depth" or "git fetch --unshallow"
+    GIT_DEPTH="--depth 1"
+else
+    # TODO: work out how to checkout another branch from a shallow clone
+    # Workaround: do not do a shallow clone
+    GIT_DEPTH=
+fi
+
+echo
+echo "Cloning $TCAT_GIT_REPOSITORY into $TCAT_DIR $GIT_DEPTH"
+git clone $GIT_DEPTH "$TCAT_GIT_REPOSITORY" "$TCAT_DIR"
+
+echo
+echo "Using branch/tag $TCAT_GIT_BRANCH"
+git -C "$TCAT_DIR" checkout "$TCAT_GIT_BRANCH"
 
 echo ""
 tput bold

--- a/helpers/urlexpand.py
+++ b/helpers/urlexpand.py
@@ -10,6 +10,7 @@ import MySQLdb
 import time
 from collections import deque
 import re
+import os.path
 
 from gevent import monkey
 monkey.patch_all(thread=False)
@@ -25,7 +26,7 @@ db_user = 'root'
 db_passwd = ''
 db_db = 'twittercapture'
 
-with open('../config.php', 'r') as f:
+with open(os.path.dirname(__file__) + '/../config.php', 'r') as f:
     read_data = f.read()
     lines = read_data.split('\n')
     for line in lines:

--- a/import/import-gnip.php
+++ b/import/import-gnip.php
@@ -3,9 +3,9 @@
 if ($argc < 1)
     die; // only run from command line
 
-include_once('../config.php');
-include_once('../common/functions.php');
-include_once('../capture/common/functions.php');
+include_once __DIR__ . '/../config.php';
+include_once __DIR__ . '/../common/functions.php';
+include_once __DIR__ . '/../capture/common/functions.php';
 
 // specify the name of the bin here 
 $bin_name = '';

--- a/import/import-jsondump.php
+++ b/import/import-jsondump.php
@@ -2,9 +2,9 @@
 
 if ($argc < 1)
     die; // only run from command line
-include_once('../config.php');
-include_once('../common/functions.php');
-include_once('../capture/common/functions.php');
+include_once __DIR__ . '/../config.php';
+include_once __DIR__ . '/../common/functions.php';
+include_once __DIR__ . '/../capture/common/functions.php';
 
 // specify the name of the bin here 
 $bin_name = '';

--- a/import/import-timeline.php
+++ b/import/import-timeline.php
@@ -1,8 +1,8 @@
 <?php
 if($argc<1) die; // only run from command line
-include_once('../config.php');
-include_once('../common/functions.php');
-include_once('../capture/common/functions.php');
+include_once __DIR__ . '/../config.php';
+include_once __DIR__ . '/../common/functions.php';
+include_once __DIR__ . '/../capture/common/functions.php';
 
 // specify the name of the bin here 
 $bin_name = '';

--- a/import/import-yourTwapperKeeper.php
+++ b/import/import-yourTwapperKeeper.php
@@ -2,9 +2,9 @@
 
 if ($argc < 1)
     die(); // only access from command line
-include_once('../config.php');
-include_once('../common/functions.php');
-include_once('../capture/common/functions.php');
+include_once __DIR__ . '/../config.php';
+include_once __DIR__ . '/../common/functions.php';
+include_once __DIR__ . '/../capture/common/functions.php';
 
 # NOTE: twitter api normally gives back url and url_expanded. YourTwapperKeeper only has url. The url expansion script which needs to be run after this one needs url_expanded to work (has to do with optimalizations). Ergo: no analysis of link shortening servies on ytk_ datasets
 // From this db


### PR DESCRIPTION
This pull request is related to [issue 170](https://github.com/digitalmethodsinitiative/dmi-tcat/issues/170).

Code changed to use the PHP built-in constant `__DIR__` to reference locations relative to the current script file. There is no longer any need for the constant `BASE_FILE`, which had to be configured when installing TCAT.

The use of `__DIR__` should mean the PHP scripts can be run from any working directory. For example, the _helpers/export.php_ and _capture/stream/controller.php_ no longer have to be run from inside those directories.
