### PR TITLE
Exporting as a download attachment instead of via a cache file

### DIFF
--- a/analysis/common/functions.php
+++ b/analysis/common/functions.php
@@ -1125,4 +1125,81 @@ function sentiment_avgs() {
     return $avgs;
 }
 
+// Prepare for data export.
+//
+// The $filename is the suggested filename and the $outputformat
+// determines the MIME type.
+//
+// Depending on the DEFAULT_USE_CACHE_FILE or "cache" query parameter, it
+// will either:
+// - output CSV/TSV directly to the HTTP response; or
+// - saves CSV/TSV to cache file and the HTTP response is a HTML page
+//
+// The default mode can overwritten with cache=y or cache=n query param
+//
+// Returns the "file" that should be opened and the results written to.
+// This will either be the provided $filename or 'php://output'.
+//
+// Will also set the global $use_cache_file variable. If true, HTML output
+// should be produced to tell the user to download the cache file, otherwise
+// no HTML output should be produced.
+
+define('DEFAULT_USE_CACHE_FILE', false); // true=old; false=new behaviour
+
+function export_start($filename, $outputformat) {
+    global $default_use_cache_file;
+    global $use_cache_file;
+    global $resultsdir;
+
+    // Determine which mode to use
+
+    $use_cache_file = DEFAULT_USE_CACHE_FILE;
+
+    if (isset($_GET['cache'])) {
+    switch ($_GET['cache']) {
+        case 'n':
+            $use_cache_file = false;
+            break;
+	case 'y':
+	    $use_cache_file = true;
+	    break;
+	default:
+            die("Invalid query parameter: cache=" . $_GET['cache']);
+	}
+    }
+
+    // Determine the MIME type
+
+    switch ($outputformat) {
+    case 'csv':
+        $mimetype = 'text/csv; charset=utf-8';
+        break;
+    case 'tsv':
+        $mimetype = 'text/tab-separated-values; charset=utf-8';
+        break;
+    default:
+        $mimetype = 'application/octet-stream';
+        break;
+    }
+
+    // Use cache file or return results as an attachment
+
+    if ($use_cache_file) {
+        // Write data to cache file
+        return $filename;
+
+    } else {
+        // Write into HTTP response
+        $suggest = 'tcat_' . basename($filename);
+
+        header("Content-Type: $mimetype");
+        header("Content-Disposition: attachment; filename=\"$suggest\"");
+        header('Cache-Control: no-cache');
+        ob_clean();
+        flush();
+
+        return 'php://output';
+    }
+}    
+
 ?>

--- a/analysis/common/functions.php
+++ b/analysis/common/functions.php
@@ -1125,6 +1125,23 @@ function sentiment_avgs() {
     return $avgs;
 }
 
+// Check if $dataset is the name of an existing query bin in $datasets.
+//
+// If it exists, nothing happens.
+// If it does not exist, an error page is produced and execution stops.
+
+function dataset_must_exist() {
+  global $dataset;
+  global $datasets;
+
+  if (! isset($datasets[$dataset])) {
+    http_response_code(404);
+    header("Content-Type: text/plain");
+    echo "Error: unknown query bin: $dataset";
+    exit(0);
+  }
+}
+
 // Prepare for data export.
 //
 // The $filename is the suggested filename and the $outputformat

--- a/analysis/index.php
+++ b/analysis/index.php
@@ -3,7 +3,6 @@ require_once __DIR__ . '/../config.php';
 require_once __DIR__ . '/common/config.php';
 require_once __DIR__ . '/common/functions.php';
 ?>
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -575,9 +574,9 @@ foreach ($linedata as $key => $value) {
                         <tr>
                             <td class="tbl_head">Graph resolution</td>
                             <td>
-                                <input type='radio' name='graph_resolution' value="day" <?php if ($graph_resolution == "day") echo "CHECKED"; ?>/> days
-                                <input type='radio' name='graph_resolution' value="hour" <?php if ($graph_resolution == "hour") echo "CHECKED"; ?>/> hours
-                                <input type='radio' name='graph_resolution' value="minute" <?php if ($graph_resolution == "minute") echo "CHECKED"; ?>/> minutes
+                                <input type='radio' name='graph_resolution' value="day" <?php if ($graph_resolution == "day") echo "CHECKED"; ?> id="grD"/> <label for="grD">days</label>
+                                <input type='radio' name='graph_resolution' value="hour" <?php if ($graph_resolution == "hour") echo "CHECKED"; ?> id="grH"/> <label for="grH">hours</label>
+                                <input type='radio' name='graph_resolution' value="minute" <?php if ($graph_resolution == "minute") echo "CHECKED"; ?> id="grM"/> <label for="grM">minutes</label>
                             </td>
                             <td><input type="submit" value="update graph" onclick="sendUrl('index.php');return false;" /></td>
                         </tr>
@@ -599,8 +598,8 @@ foreach ($linedata as $key => $value) {
                 <p>
                     <div class='txt_desc' style='background-color: #eee; padding: 5px;'>Output format for tables:
                         <form>
-                            <input type='radio' name="outputformat" value="csv"<?php if ($outputformat == 'csv') print " CHECKED"; ?>>CSV (comma-separated)</input>
-                            <input type='radio' name="outputformat" value="tsv"<?php if ($outputformat == 'tsv') print " CHECKED"; ?>>TSV (tab-separated)</input>
+                            <input type='radio' name="outputformat" value="csv"<?php if ($outputformat == 'csv') print " CHECKED"; ?> id="ofCSV"> <label for="ofCSV">CSV (comma-separated)</label>
+                            <input type='radio' name="outputformat" value="tsv"<?php if ($outputformat == 'tsv') print " CHECKED"; ?> id="ofTSV"> <label for="ofTSV">TSV (tab-separated)</label>
                         </form>
                     </div>
                 </p>
@@ -613,14 +612,14 @@ foreach ($linedata as $key => $value) {
 
                     <div class='txt_desc' style='background-color: #eee; padding: 5px;'>Here you can select how the statistics should be grouped:
                         <form>
-                            <input type='radio' name="interval" value="overall"<?php if ($interval == 'overall') print " CHECKED"; ?>>overall</input>
-                            <input type='radio' name="interval" value="hourly"<?php if ($interval == 'hourly') print " CHECKED"; ?>>per hour</input>
-                            <input type='radio' name="interval" value="daily"<?php if ($interval == 'daily') print " CHECKED"; ?>>per day</input>
-                            <input type='radio' name="interval" value="weekly"<?php if ($interval == 'weekly') print " CHECKED"; ?>>per week</input>
-                            <input type='radio' name="interval" value="monthly"<?php if ($interval == 'monthly') print " CHECKED"; ?>>per month</input>
-                            <input type='radio' name="interval" value="yearly"<?php if ($interval == 'yearly') print " CHECKED"; ?>>per year</input>
-                            <input type='radio' name="interval" value="custom"<?php if ($interval == 'custom') print " CHECKED"; ?>>custom:</input>
-                            <input type='text' name='customInterval' size='50' value='<?php if (!empty($intervalDates)) print $_REQUEST['customInterval']; else print "YYYY-MM-DD;YYYY-MM-DD;...;YYYY-MM-DD"; ?>'></input>
+                            <input type='radio' name="interval" value="overall"<?php if ($interval == 'overall') print " CHECKED"; ?> id="tsam1"> <label for="tsam1">overall</label>
+                            <input type='radio' name="interval" value="hourly"<?php if ($interval == 'hourly') print " CHECKED"; ?> id="tsam2"> <label for="tsam2">per hour</label>
+                            <input type='radio' name="interval" value="daily"<?php if ($interval == 'daily') print " CHECKED"; ?> id="tsam3"> <label for="tsam3">per day</label>
+                            <input type='radio' name="interval" value="weekly"<?php if ($interval == 'weekly') print " CHECKED"; ?> id="tsam4"> <label for="tsam4">per week</label>
+                            <input type='radio' name="interval" value="monthly"<?php if ($interval == 'monthly') print " CHECKED"; ?> id="tsam5"> <label for="tsam5">per month</label>
+                            <input type='radio' name="interval" value="yearly"<?php if ($interval == 'yearly') print " CHECKED"; ?> id="tsam6"> <label for="tsam6">per year</label>
+                            <input type='radio' name="interval" value="custom"<?php if ($interval == 'custom') print " CHECKED"; ?> id="tsam7"> <label for="tsam7">custom:</label>
+                            <input type='text' name='customInterval' size='50' value='<?php if (!empty($intervalDates)) print $_REQUEST['customInterval']; else print "YYYY-MM-DD;YYYY-MM-DD;...;YYYY-MM-DD"; ?>'/>
                         </form>
                     </div>
 
@@ -730,7 +729,7 @@ foreach ($linedata as $key => $value) {
 
                 <div class="if_export_block">
 
-                    <div class="txt_desc">All tweet exports come as a .csv file which you can open in Excel or similar.</div>
+                    <div class="txt_desc">All tweet exports produces a .csv or .tsv file which you can open in Excel or similar.</div>
                     <div class='txt_desc' style='background-color: #eee; padding: 5px;'>Here you can select additional columns for the tweet exports (more = slower):
                         <form style='display:inline;'>
                             <?php
@@ -741,22 +740,22 @@ foreach ($linedata as $key => $value) {
                             <?php if ($show_url_export) { ?>
                                 <input type='checkbox' name="exportSettings" value="urls" <?php if (array_search("urls", $exportSettings) !== false) print "CHECKED"; ?>>URLs</input>
                             <?php } ?>
-                            <input type='checkbox' name="exportSettings" value="mentions" <?php if (array_search("mentions", $exportSettings) !== false) print "CHECKED"; ?>>mentions</input>
-                            <input type='checkbox' name="exportSettings" value="hashtags" <?php if (array_search("hashtags", $exportSettings) !== false) print "CHECKED"; ?>>hashtags</input>
-                            <input type='checkbox' name="exportSettings" value="media" <?php if (array_search("media", $exportSettings) !== false) print "CHECKED"; ?>>media</input>
+                            <input type='checkbox' name="exportSettings" value="mentions" <?php if (array_search("mentions", $exportSettings) !== false) print "CHECKED"; ?> id="esMentions"/> <label for="esMentions">mentions</label>
+                            <input type='checkbox' name="exportSettings" value="hashtags" <?php if (array_search("hashtags", $exportSettings) !== false) print "CHECKED"; ?> id="esHashtags"> <label for="esHashtags">hashtags</label>
+                            <input type='checkbox' name="exportSettings" value="media" <?php if (array_search("media", $exportSettings) !== false) print "CHECKED"; ?> id="esMedia"> <label for="esMedia">media</label>
                         </form>
                     </div>
 
                     <h3>Random set of tweets from selection</h3>
                     <div class="txt_desc">Contains 1000 randomly selected tweets and information about them (user, date created, ...).</div>
                     <div class="txt_desc">Use: a random subset of tweets is a representative sample that can be manually classified and coded much more easily than the full set.</div>
-                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_tweets&random=1'+getExportSettings());sendUrl('mod.export_tweets.php');return false;">launch</a></div>
+                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_tweets&random=1'+getExportSettings());sendUrl('mod.export_tweets.php');return false;">download</a></div>
                     <hr />
 
                     <h3>Export all tweets from selection</h3>
                     <div class="txt_desc">Contains all tweets and information about them (user, date created, ...).</div>
                     <div class="txt_desc">Use: spend time with your data.</div>
-                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_tweets'+getExportSettings());sendUrl('mod.export_tweets.php');return false;">export</a></div>
+                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_tweets'+getExportSettings());sendUrl('mod.export_tweets.php');return false;">download</a></div>
                     <hr />
 
                     <?php if ($show_lang_export) { ?>
@@ -774,35 +773,35 @@ foreach ($linedata as $key => $value) {
                     <div class="txt_desc">Lists all retweets (and all the tweets metadata like follower_count) chronologically.</div>
                     <div class="txt_desc">Use: reconstruct retweet chains.</div>
                     <div class="txt_desc"><b>Warning:</b> This script is slow. Small datasets only!</div>
-                    <div class="txt_link"> &raquo; <a href="" onclick="var minf = askRetweetFrequency(); $('#whattodo').val('retweets_chain&minf='+minf+getExportSettings());sendUrl('mod.retweets_chain.php');return false;">launch</a></div>
+                    <div class="txt_link"> &raquo; <a href="" onclick="var minf = askRetweetFrequency(); $('#whattodo').val('retweets_chain&minf='+minf+getExportSettings());sendUrl('mod.retweets_chain.php');return false;">download</a></div>
 
                     <hr />
 
                     <h3>Only tweets with lat/lon</h3>
                     <div class="txt_desc">Contains only geo-located tweets.</div>
                     <div class="txt_desc"></div>
-                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_tweets&location=1'+getExportSettings());sendUrl('mod.export_tweets.php');return false;">launch</a></div>
+                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_tweets&location=1'+getExportSettings());sendUrl('mod.export_tweets.php');return false;">download</a></div>
 
                     <hr />
 
                     <h3>Export tweet ids</h3>
                     <div class="txt_desc">Contains only the tweet ids from your selection.</div>
                     <div class="txt_desc"></div>
-                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_tweet_ids');sendUrl('mod.export_tweet_ids.php');return false;">launch</a></div>
+                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_tweet_ids');sendUrl('mod.export_tweet_ids.php');return false;">download</a></div>
 
                     <hr />
 
                     <h3>Export hashtag table (tweet id, hashtag)</h3>
                     <div class="txt_desc">Contains tweet ids from your selection and hashtags.</div>
                     <div class="txt_desc"></div>
-                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_hashtags');sendUrl('mod.export_hashtags.php');return false;">launch</a></div>
+                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_hashtags');sendUrl('mod.export_hashtags.php');return false;">download</a></div>
 
                     <hr />
 
                     <h3>Export mentions table (tweet id, user from id, user from name, user to id, user to name, mention, mention type)</h3>
                     <div class="txt_desc">Contains tweet ids from your selection, with mentions and the mention type.</div>
                     <div class="txt_desc"></div>
-                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_mentions');sendUrl('mod.export_mentions.php');return false;">launch</a></div>
+                    <div class="txt_link"> &raquo;  <a href="" onclick="$('#whattodo').val('export_mentions');sendUrl('mod.export_mentions.php');return false;">download</a></div>
 
                     <?php if ($show_url_export) { ?>
 

--- a/analysis/mod.export_hashtags.php
+++ b/analysis/mod.export_hashtags.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/common/functions.php';
 require_once __DIR__ . '/common/CSV.class.php';
 
         validate_all_variables();
+        dataset_must_exist();
 
         $filename = get_filename_for_export('hashtagExport');
         $stream_to_open = export_start($filename, $outputformat);

--- a/analysis/mod.export_hashtags.php
+++ b/analysis/mod.export_hashtags.php
@@ -2,8 +2,38 @@
 require_once __DIR__ . '/common/config.php';
 require_once __DIR__ . '/common/functions.php';
 require_once __DIR__ . '/common/CSV.class.php';
-?>
 
+        validate_all_variables();
+
+        $filename = get_filename_for_export('hashtagExport');
+        $stream_to_open = export_start($filename, $outputformat);
+	
+        $csv = new CSV($stream_to_open, $outputformat);
+
+        $csv->writeheader(array('tweet_id', 'hashtag'));
+
+        $sql = "SELECT t.id as id, h.text as hashtag FROM " . $esc['mysql']['dataset'] . "_tweets t, " . $esc['mysql']['dataset'] . "_hashtags h ";
+        $sql .= sqlSubset();
+        $sql .= " AND h.tweet_id = t.id ORDER BY id";
+        $sqlresults = mysql_unbuffered_query($sql);
+        $out = "";
+        if ($sqlresults) {
+            while ($data = mysql_fetch_assoc($sqlresults)) {
+                $csv->newrow();    
+                $csv->addfield($data['id'], 'integer');
+                $csv->addfield($data['hashtag'], 'string');
+                $csv->writerow();
+            }
+            mysql_free_result($sqlresults);
+        }
+
+        $csv->close();
+
+    if (! $use_cache_file) {
+        exit(0);
+    }
+    // Rest of script is the HTML page with a link to the cached CSV/TSV file.
+?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -27,30 +57,6 @@ require_once __DIR__ . '/common/CSV.class.php';
         <h1>TCAT :: Export hashtags</h1>
 
         <?php
-        validate_all_variables();
-
-        $filename = get_filename_for_export('hashtagExport');
-        $csv = new CSV($filename, $outputformat);
-
-        $csv->writeheader(array('tweet_id', 'hashtag'));
-
-        $sql = "SELECT t.id as id, h.text as hashtag FROM " . $esc['mysql']['dataset'] . "_tweets t, " . $esc['mysql']['dataset'] . "_hashtags h ";
-        $sql .= sqlSubset();
-        $sql .= " AND h.tweet_id = t.id ORDER BY id";
-        $sqlresults = mysql_unbuffered_query($sql);
-        $out = "";
-        if ($sqlresults) {
-            while ($data = mysql_fetch_assoc($sqlresults)) {
-                $csv->newrow();    
-                $csv->addfield($data['id'], 'integer');
-                $csv->addfield($data['hashtag'], 'string');
-                $csv->writerow();
-            }
-            mysql_free_result($sqlresults);
-        }
-
-        $csv->close();
-
         echo '<fieldset class="if_parameters">';
         echo '<legend>Your File</legend>';
         echo '<p><a href="' . filename_to_url($filename) . '">' . $filename . '</a></p>';

--- a/analysis/mod.export_mentions.php
+++ b/analysis/mod.export_mentions.php
@@ -3,35 +3,12 @@ require_once __DIR__ . '/common/config.php';
 require_once __DIR__ . '/common/functions.php';
 require_once __DIR__ . '/common/CSV.class.php';
 
-?>
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-        <title>TCAT :: Export mentions</title>
-
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-
-        <link rel="stylesheet" href="css/main.css" type="text/css" />
-
-        <script type="text/javascript" language="javascript">
-	
-	
-	
-        </script>
-
-    </head>
-
-    <body>
-
-        <h1>TCAT :: Export mentions</h1>
-
-        <?php
         validate_all_variables();
 
         $filename = get_filename_for_export('mentionExport');
-        $csv = new CSV($filename, $outputformat);
+        $stream_to_open = export_start($filename, $outputformat);
+
+        $csv = new CSV($stream_to_open, $outputformat);
 
         $csv->writeheader(array('tweet_id', 'user_from_id', 'user_from_name', 'user_to_id', 'user_to_name', 'mention_type'));
 
@@ -56,6 +33,34 @@ require_once __DIR__ . '/common/CSV.class.php';
 
         $csv->close();
 
+    if (! $use_cache_file) {
+        exit(0);
+    }
+    // Rest of script is the HTML page with a link to the cached CSV/TSV file.
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>TCAT :: Export mentions</title>
+
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+        <link rel="stylesheet" href="css/main.css" type="text/css" />
+
+        <script type="text/javascript" language="javascript">
+	
+	
+	
+        </script>
+
+    </head>
+
+    <body>
+
+        <h1>TCAT :: Export mentions</h1>
+
+        <?php
         echo '<fieldset class="if_parameters">';
         echo '<legend>Your File</legend>';
         echo '<p><a href="' . filename_to_url($filename) . '">' . $filename . '</a></p>';

--- a/analysis/mod.export_mentions.php
+++ b/analysis/mod.export_mentions.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/common/functions.php';
 require_once __DIR__ . '/common/CSV.class.php';
 
         validate_all_variables();
+        dataset_must_exist();
 
         $filename = get_filename_for_export('mentionExport');
         $stream_to_open = export_start($filename, $outputformat);

--- a/analysis/mod.export_tweet_ids.php
+++ b/analysis/mod.export_tweet_ids.php
@@ -2,11 +2,11 @@
 require_once __DIR__ . '/common/config.php';
 require_once __DIR__ . '/common/functions.php';
 
-$filename = get_filename_for_export("ids");
-$stream_to_open = export_start($filename, $outputformat);
-
         validate_all_variables();
+        dataset_must_exist();
 
+        $filename = get_filename_for_export("ids");
+        $stream_to_open = export_start($filename, $outputformat);
 
         $sql = "SELECT id FROM " . $esc['mysql']['dataset'] . "_tweets t ";
         $sql .= sqlSubset();

--- a/analysis/mod.export_tweets.php
+++ b/analysis/mod.export_tweets.php
@@ -2,31 +2,7 @@
 require_once __DIR__ . '/common/config.php';
 require_once __DIR__ . '/common/functions.php';
 require_once __DIR__ . '/common/CSV.class.php';
-?>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-        <title>TCAT :: Export Tweets</title>
-
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-
-        <link rel="stylesheet" href="css/main.css" type="text/css" />
-
-        <script type="text/javascript" language="javascript">
-
-
-
-        </script>
-
-    </head>
-
-    <body>
-
-        <h1>TCAT :: Export Tweets</h1>
-
-        <?php
         validate_all_variables();
         // make filename and open file for write
         $module = "fullExport";
@@ -40,7 +16,9 @@ require_once __DIR__ . '/common/CSV.class.php';
         if ((isset($_GET['location']) && $_GET['location'] == 1))
             $module = "geoTweets";
         $filename = get_filename_for_export($module, implode("_", $exportSettings));
-        $csv = new CSV($filename, $outputformat);
+        $stream_to_open = export_start($filename, $outputformat);
+	
+        $csv = new CSV($stream_to_open, $outputformat);
 
         // write header
         $header = "id,time,created_at,from_user_name,text,filter_level,possibly_sensitive,withheld_copyright,withheld_scope,truncated,retweet_count,favorite_count,lang,to_user_name,in_reply_to_status_id,quoted_status_id,source,location,lat,lng,from_user_id,from_user_realname,from_user_verified,from_user_description,from_user_url,from_user_profile_image_url,from_user_utcoffset,from_user_timezone,from_user_lang,from_user_tweetcount,from_user_followercount,from_user_friendcount,from_user_favourites_count,from_user_listed,from_user_withheld_scope,from_user_created_at";
@@ -192,11 +170,40 @@ require_once __DIR__ . '/common/CSV.class.php';
         }
         $csv->close();
 
+    if (! $use_cache_file) {
+        exit(0);
+    }
+    // Rest of script is the HTML page with a link to the cached CSV/TSV file.
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>TCAT :: Export Tweets</title>
+
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+        <link rel="stylesheet" href="css/main.css" type="text/css" />
+
+        <script type="text/javascript" language="javascript">
+
+        </script>
+
+    </head>
+
+    <body>
+
+        <h1>TCAT :: Export Tweets</h1>
+
+<?php
         echo '<fieldset class="if_parameters">';
         echo '<legend>Your File</legend>';
-        echo '<p><a href="' . filename_to_url($filename) . '">' . $filename . '</a></p>';
+	echo '<p>';
+        echo '<a href="' . htmlspecialchars(filename_to_url($filename)) . '">';
+	echo htmlspecialchars($filename);
+	echo '</a></p>';
         echo '</fieldset>';
-        ?>
+?>
 
     </body>
 </html>

--- a/analysis/mod.export_tweets.php
+++ b/analysis/mod.export_tweets.php
@@ -4,6 +4,8 @@ require_once __DIR__ . '/common/functions.php';
 require_once __DIR__ . '/common/CSV.class.php';
 
         validate_all_variables();
+        dataset_must_exist();
+
         // make filename and open file for write
         $module = "fullExport";
         $exportSettings = array();

--- a/analysis/mod.retweets_chain.php
+++ b/analysis/mod.retweets_chain.php
@@ -2,31 +2,7 @@
 require_once __DIR__ . '/common/config.php';
 require_once __DIR__ . '/common/functions.php';
 require_once __DIR__ . '/common/CSV.class.php';
-?>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-        <title>TCAT :: Export retweet chain</title>
-
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-
-        <link rel="stylesheet" href="css/main.css" type="text/css" />
-
-        <script type="text/javascript" language="javascript">
-	
-	
-	
-        </script>
-
-    </head>
-
-    <body>
-
-        <h1>TCAT :: Export retweet chain</h1>
-
-        <?php
         validate_all_variables();
         $collation = current_collation();
         $min_nr_of_nodes = (isset($_GET['minf']) && is_numeric($_GET['minf'])) ? $min_nr_of_nodes = $_GET['minf'] : 4;
@@ -38,7 +14,9 @@ require_once __DIR__ . '/common/CSV.class.php';
             $exportSettings = explode(",", $_GET['exportSettings']);
         $exportSettings[] = $min_nr_of_nodes;
         $filename = get_filename_for_export($module, implode("_", $exportSettings));
-        $csv = new CSV($filename, $outputformat);
+        $stream_to_open = export_start($filename, $outputformat);
+
+        $csv = new CSV($stream_to_open, $outputformat);
 
         // write header
         $header = "id,time,created_at,from_user_name,text,filter_level,possibly_sensitive,withheld_copyright,withheld_scope,truncated,favorite_count,lang,to_user_name,in_reply_to_status_id,source,location,lat,lng,from_user_id,from_user_realname,from_user_verified,from_user_description,from_user_url,from_user_profile_image_url,from_user_utcoffset,from_user_timezone,from_user_lang,from_user_followercount,from_user_friendcount,from_user_favourites_count,from_user_listed,from_user_withheld_scope,from_user_created_at";
@@ -65,8 +43,8 @@ require_once __DIR__ . '/common/CSV.class.php';
         $sql .= "GROUP BY text HAVING count >= " . $min_nr_of_nodes . " ORDER BY count DESC";
         $rec = mysql_query($sql);
         
-        print mysql_num_rows($rec) . " retweet chains found with more than " . $min_nr_of_nodes . " tweets<br>";
-        flush();
+        // print mysql_num_rows($rec) . " retweet chains found with more than " . $min_nr_of_nodes . " tweets<br>";
+        // flush();
 
         while ($res = mysql_fetch_assoc($rec)) {
 
@@ -167,7 +145,35 @@ require_once __DIR__ . '/common/CSV.class.php';
             }
         }
         $csv->close();
-        
+
+if (! $use_cache_file) {
+        exit(0);
+    }
+    // Rest of script is the HTML page with a link to the cached CSV/TSV file.
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>TCAT :: Export retweet chain</title>
+
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+        <link rel="stylesheet" href="css/main.css" type="text/css" />
+
+        <script type="text/javascript" language="javascript">
+	
+	
+	
+        </script>
+
+    </head>
+
+    <body>
+
+        <h1>TCAT :: Export retweet chain</h1>
+
+        <?php       
         echo '<fieldset class="if_parameters">';
         echo '<legend>Your File</legend>';
         echo '<p><a href="' . filename_to_url($filename) . '">' . $filename . '</a></p>';

--- a/analysis/mod.retweets_chain.php
+++ b/analysis/mod.retweets_chain.php
@@ -4,6 +4,8 @@ require_once __DIR__ . '/common/functions.php';
 require_once __DIR__ . '/common/CSV.class.php';
 
         validate_all_variables();
+        dataset_must_exist();
+
         $collation = current_collation();
         $min_nr_of_nodes = (isset($_GET['minf']) && is_numeric($_GET['minf'])) ? $min_nr_of_nodes = $_GET['minf'] : 4;
 

--- a/helpers/tcat-install-linux.sh
+++ b/helpers/tcat-install-linux.sh
@@ -1002,7 +1002,7 @@ TCAT_GIT_BRANCH=master
 # e.g. testing change from BASE_FILE to __DIR__: run in debug mode
 if [ "$DEBUG_MODE" = 'y' ]; then
     TCAT_GIT_REPOSITORY=https://github.com/hoylen/dmi-tcat.git
-    TCAT_GIT_BRANCH=BASE_FILE
+    TCAT_GIT_BRANCH="export-direct"
 fi
 
 if [ "$TCAT_GIT_BRANCH" == 'master' ]; then


### PR DESCRIPTION
This change makes all the "tweet export" links output the CSV/TSV directly to the HTTP response, instead of creating a cache file and then showing the user a HTML page asking them to download it. No file is produced in the _analysis/cache_ directory and the user does not need to perform a second action to download the data.

This is a part-solution to issue #189.

The 7 links on the analysis index page has been changed to say "download" (from "launch" or "export") to reflect this new one-step behaviour.

The old behaviour is still supported and can be entirely switched back by changing a constant in _analysis/common/functions.php_, or individually by adding a `cache=y` query parameter to the URL. If switched back by setting the constant, it can be individually enabled by adding a `cache=n` query parameter to the URL.

Does anyone actually want to keep the old behaviour? If not, we can delete the extra code that supports the old behaviour.

I've only changed the "tweet export" functions, but maybe the other analysis functions might want to be changed in the same way? They seem to also follow the two-step cache-file approach.

For testing, you can install this pull request's branch by running this branch's updated installer with the undocumented debug mode:

    curl -O https://raw.githubusercontent.com/hoylen/dmi-tcat/export-direct/helpers/tcat-install-linux.sh
    chmod a+x tcat-install-linux.sh
    sudo ./tcat-install-linux.sh -D

Alternatively, I've installed it at http://203.101.234.83/analysis/ (username: tcat, password: 2xD5K2VWgJJTt9RGx9zAxzxL6hpMV7wuAaNds ) and will leave it up for a few days. The query bins on it have been stopped, so there are only a few tweets in them.