### PR TITLE
Added link from capture page to analysis page.

### DIFF
--- a/analysis/css/main.css
+++ b/analysis/css/main.css
@@ -25,7 +25,8 @@ hr { border:0; color:#aaa; background-color:#aaa; height:1px; width:100%; margin
 
 /* classes */
 
-.if_toplinks { font-size:12px; text-decoration:none; color: #000; }
+.if_toplinks { display: inline-block; margin-left: 1em; font-size:12px; text-decoration:none; color: #000; }
+.if_toplinks:before { content: "» "; }
 .if_toplinks:hover { text-decoration:underline; }
 
 .if_panel_box { float:left; margin:10px 0px 10px 0px; }

--- a/analysis/index.php
+++ b/analysis/index.php
@@ -156,12 +156,12 @@ if (defined('ANALYSIS_URL'))
             <h1 id="if_title">DMI Twitter Capturing and Analysis Toolset (DMI-TCAT)</h1>
 
             <div id="if_links">
-                &raquo; <a href="https://github.com/digitalmethodsinitiative/dmi-tcat" target="_blank" class="if_toplinks">github</a>&nbsp;&nbsp;&nbsp;
-                &raquo; <a href="https://github.com/digitalmethodsinitiative/dmi-tcat/issues?state=open" target="_blank" class="if_toplinks">issues</a>&nbsp;&nbsp;&nbsp;
-                &raquo; <a href="https://github.com/digitalmethodsinitiative/dmi-tcat/wiki" target="_blank" class="if_toplinks">FAQ</a>
+                <a href="https://github.com/digitalmethodsinitiative/dmi-tcat" target="_blank" class="if_toplinks">github</a>
+                <a href="https://github.com/digitalmethodsinitiative/dmi-tcat/issues?state=open" target="_blank" class="if_toplinks">issues</a>
+                <a href="https://github.com/digitalmethodsinitiative/dmi-tcat/wiki" target="_blank" class="if_toplinks">FAQ</a>
                 <?php
                 if (defined("ADMIN_USER") && ADMIN_USER != "" && isset($_SERVER['PHP_AUTH_USER']) && $_SERVER['PHP_AUTH_USER'] == ADMIN_USER)
-                    print '&nbsp;&nbsp;&nbsp; &raquo; <a href="../capture/index.php" target="_blank" class="if_toplinks">admin</a>';
+                    print '<a href="../capture/index.php" class="if_toplinks">admin</a>';
                 ?>
             </div>
 

--- a/capture/index.php
+++ b/capture/index.php
@@ -37,6 +37,17 @@ $lastRateLimitHit = getLastRateLimitHit();
             td { background-color: #eee; padding:5px; }
             .keywords { width:400px; }
 
+            #if_fullpage { width:1000px; }
+
+            h1 { font-size:16px; margin:20px 0px 15px 0px; }
+
+            #if_title { float:left; }
+            #if_links { float:right; padding-top:22px; margin-right:-20px; }
+
+            .if_toplinks { display: inline-block; margin-left: 1em; font-size:12px; text-decoration:none; color: #000; }
+            .if_toplinks:before { content: "» "; }
+            .if_toplinks:hover { text-decoration:underline; }
+
             .if_row { padding:2px; position: relative; width: 1024px; clear: both;}
             .if_row_header{ width: 100px; height: 20px; float: left; padding-top: 5px;}
             .if_row_content input { width: 320px; }
@@ -71,8 +82,17 @@ $lastRateLimitHit = getLastRateLimitHit();
     </head>
 
     <body>
+        <div id="if_fullpage">
+        <h1 id="if_title">DMI-TCAT query manager</h1>
+        <div id="if_links">
+            <a href="https://github.com/digitalmethodsinitiative/dmi-tcat" target="_blank" class="if_toplinks">github</a>
+            <a href="https://github.com/digitalmethodsinitiative/dmi-tcat/issues?state=open" target="_blank" class="if_toplinks">issues</a>
+            <a href="https://github.com/digitalmethodsinitiative/dmi-tcat/wiki" target="_blank" class="if_toplinks">FAQ</a>
+            <a href="../analysis/index.php" class="if_toplinks">analysis</a>
+        </div>
+        <div style="clear:both;"></div>
+        </div>
 
-        <h1>DMI-TCAT query manager</h1>
         <?php
         if (!dbserver_has_utf8mb4_support()) {
             print "<br /><font color='red'>Your MySQL version is too old, please upgrade to at least MySQL 5.5.3 to use DMI-TCAT.</font><br>";


### PR DESCRIPTION
Here is a pull request for #171.

- Navigation links have been added to the capture page, to go to the analysis page.
- Removed `target="_blank"` from navigation link from analysis page to capture page, otherwise multiple tabs/windows will get created if the user navigates back and forwards between those two pages.
- Used CSS margins instead of padding the links out with lots of `&nbsp;`
