### PR TITLE
Withheld table: index on tweet_id column created on the correct column

### DIFF
--- a/capture/common/functions.php
+++ b/capture/common/functions.php
@@ -85,7 +85,7 @@ function create_bin($bin_name, $dbh = false) {
             `country` char(5),
             PRIMARY KEY (`id`),
                     KEY `user_id` (`user_id`),
-                    KEY `tweet_id` (`user_id`),
+                    KEY `tweet_id` (`tweet_id`),
                     KEY `country` (`country`)
             ) ENGINE=MyISAM  DEFAULT CHARSET=utf8mb4";
 

--- a/capture/index.php
+++ b/capture/index.php
@@ -163,12 +163,13 @@ $lastRateLimitHit = getLastRateLimitHit();
                                         <option value="onepercent">one percent sample</option>
                         <?php } ?>
                                 </select>
+                                <span>(cannot be changed later on)</span>
                             </div>
                         </div>
                         <div class="if_row">
                             <div class='if_row_header'>Bin name:</div>
                             <div class='if_row_content'>
-                                <input id="newbin_name" name="newbin_name" type="text"/> (cannot be changed later on)
+                                <input id="newbin_name" name="newbin_name" type="text"/>
                             </div>
                         </div>
 <?php if (array_search('track', $captureroles) !== false) { ?>


### PR DESCRIPTION
To minor fixes:

An index called "tweet_id" was being created on the `*_withdraw tables`, but it was on the `user_id` column. There is already another index on the `user_id` column called "user_id".

Also moved the text saying it "cannot be changed" after the query bin was created. It was next to the name of the query bin text field, and not next to the type of the query bin selector. Query bins can be renamed. It is their type that can't be changed.
