### PR TITLE
Install bug fixes

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -15,19 +15,19 @@ $hostname = "localhost";
  * Possible values are "track", "follow", "onepercent". 
  * Note that you can only do one of track, follow or onepercent per IP address and capturing key
  */
-define("CAPTUREROLES", serialize(array("track")));
+define('CAPTUREROLES', serialize(array('track')));
 
 /*
  * The user who can add and modify query bins. 
  * This user should exist in your htaccess authentication
  * Leave empty if you do not want to restrict access to the query manager - which, of course, is a security risk
  */
-define("ADMIN_USER", "admin");
+define('ADMIN_USER', 'admin');
 
 /*
  * *Super advanced and currently undocumented feature, leave settings as they are*
  * We have made it possible to tunnel Twitter API connections through other hosts (obtaining a different source IP address), and use multiple keysets for multiple streaming queries.
- * Each capture script should define its role, see define("CAPTUREROLES",serialize(array()))
+ * Each capture script should define its role, see define('CAPTUREROLES',serialize(array()))
  * Every distinct role should then get a different network path below
  * 
  */
@@ -72,7 +72,7 @@ $twitter_keys = array(
 /**
 
 // Make sure you have a key for each capture role defined in CAPTUREROLES above
-if (!defined('CAPTURE') || !strcmp(CAPTURE, "track")) {
+if (!defined('CAPTURE') || !strcmp(CAPTURE, 'track')) {
     $twitter_consumer_key = "";
     $twitter_consumer_secret = "";
     $twitter_user_token = "";
@@ -178,7 +178,7 @@ mb_internal_encoding("UTF-8");
  * set location of php
  * find the location by typing 'which php' on the command line of your terminal
  */
-define("PHP_CLI", "/usr/bin/php");
+define('PHP_CLI', '/usr/bin/php');
 
 /*
  * Use mysql INSERT DELAYED statements to insert data into the MySQL database.

--- a/config.php.example
+++ b/config.php.example
@@ -140,7 +140,7 @@ define('RATELIMIT_MAIL_HOURS', 24);
 /*
  * Time zone
  */
-date_default_timezone_set("Europe/London");
+date_default_timezone_set('UTC'); // Warning: must be 'UTC'. Do not change!
 
 /*
  * Error reporting verbosity

--- a/helpers/tcat-install-linux.sh
+++ b/helpers/tcat-install-linux.sh
@@ -871,7 +871,7 @@ if [ -z "$TCATADMINPASS" ]; then
     TCATADMINPASS=`openssl rand -base64 32 | tr -c -d 0-9A-Za-z | tr -d O01iIl`
     TCATADMINPASS_GENERATED=y
 else
-    TCATPASS_GENERATED=
+    TCATADMINPASS_GENERATED=
 fi
 
 if [ -z "$TCATPASS" ]; then


### PR DESCRIPTION
Fixes three bugs in the install script.

- In the install script, `TCATADMINPASS_GENERATED` was not set (due to copy-and-paste error) and that resulted in a harmless error at the very end of the script. It is harmless in the sense that TCAT was completely installed, but the script aborted before the last part of the final text was printed out.

- In the sample _config.php.example_ file, all `define("VARIABLE_NAME", ...)` statements have been changed to `define('VARIABLE_NAME', ...)` -- double quotes to single quotes. One of the _sed_ commands in the install script failed to work because it was expecting to match a pattern with single quotes. Installs that customised the TCAT admin Web login username failed to change "admin" to the required value. For these string values, single quotes are nicer than double quotes, since it signals that we do not expect variables substitution to occur inside them. A better solution would be to change the _sed_ regular expression to work with either single or double quotes, but that results in a regular expression that is much more complicated and harder for readers to understand.

- The timezone set by the _config.php.example_ file is changed from "Europe/London" to "UTC". Otherwise, tweets in this half of the year appear to arrive 1 hour in the future. It must not be set to any other value (maybe it should be moved into another PHP file). This is a workaround, until a more comprehensive fix to how timestamps and timezones are handled in TCAT.