### PR TITLE
RESTful API enhancements

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -2,6 +2,8 @@
 require_once __DIR__ . '/lib/common.php';
 require_once __DIR__ . '/lib/http_util.php';
 
+expected_query_parameters([]); // no query parameters permitted
+
 switch (choose_mediatype(['application/json', 'text/html', 'text/plain'])) {
     case 'application/json':
         respond_with_json(['name' => 'DMI-TCAT API',

--- a/api/index.php
+++ b/api/index.php
@@ -2,7 +2,12 @@
 require_once __DIR__ . '/lib/common.php';
 require_once __DIR__ . '/lib/http_util.php';
 
-switch (choose_mediatype(['text/html'])) {
+switch (choose_mediatype(['application/json', 'text/html'])) {
+    case 'application/json':
+        respond_with_json(['name' => 'DMI-TCAT API',
+                           'version' => API_VERSION]);
+        break;
+
     case 'text/html':
         html_begin("API", []);
         echo <<<END

--- a/api/index.php
+++ b/api/index.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/lib/common.php';
 require_once __DIR__ . '/lib/http_util.php';
 
-switch (choose_mediatype(['application/json', 'text/html'])) {
+switch (choose_mediatype(['application/json', 'text/html', 'text/plain'])) {
     case 'application/json':
         respond_with_json(['name' => 'DMI-TCAT API',
                            'version' => API_VERSION]);
@@ -20,6 +20,11 @@ END;
         echo "<p>Version: ", API_VERSION, "</p>\n";
         html_end();
         break;
+
+    case 'text/plain':
+        echo "DMI-TCAT API (version: ", API_VERSION, ")\n";
+        break;
+
     default:
         echo "DMI-TCAT API (version: ", API_VERSION, ")\n";
         echo "  Running this script from the command line does nothing useful!\n";

--- a/api/querybin.php
+++ b/api/querybin.php
@@ -186,7 +186,7 @@ function do_view_or_export_tweets(array $querybin, $dt_start, $dt_end, $export)
 
     // Show result
 
-    $response_mediatype = choose_mediatype(['text/html',
+    $response_mediatype = choose_mediatype(['application/json', 'text/html',
         'text/csv', 'text/tab-separated-values']);
 
     if (isset($export)) {
@@ -418,6 +418,13 @@ END;
             // End of page
 
             html_end();
+            break;
+
+        case 'application/json':
+            $data = [
+               "number-selected-tweets" => $info['tweets'],
+            ];
+            respond_with_json($data);
             break;
 
         default:

--- a/api/querybin.php
+++ b/api/querybin.php
@@ -33,7 +33,8 @@ function do_list_bins()
         $datasets = []; // database tables not yet initialized
     }
 
-    $response_mediatype = choose_mediatype(['application/json', 'text/html']);
+    $response_mediatype = choose_mediatype(['application/json', 'text/html',
+                                            'text/plain']);
 
     switch ($response_mediatype) {
         case 'application/json':
@@ -62,6 +63,8 @@ function do_list_bins()
 
             html_end();
             break;
+
+        case 'text/plain':
         default:
             foreach (array_keys($datasets) as $name) {
                 print($name . "\n");
@@ -79,7 +82,7 @@ function do_bin_info(array $querybin)
 {
     global $api_timezone;
 
-    $response_mediatype = choose_mediatype(['application/json', 'text/html']);
+    $response_mediatype = choose_mediatype(['application/json', 'text/html', 'text/plain']);
 
     switch ($response_mediatype) {
         case 'application/json':
@@ -138,6 +141,7 @@ function do_bin_info(array $querybin)
             html_end();
             break;
 
+        case 'text/plain':
         default:
             print("Query bin: {$querybin['bin']}\n");
 
@@ -187,6 +191,7 @@ function do_view_or_export_tweets(array $querybin, $dt_start, $dt_end, $export)
     // Show result
 
     $response_mediatype = choose_mediatype(['application/json', 'text/html',
+        'text/plain',
         'text/csv', 'text/tab-separated-values']);
 
     if (isset($export)) {
@@ -427,6 +432,7 @@ END;
             respond_with_json($data);
             break;
 
+        case 'text/plain':
         default:
 
             $from = (isset($dt_start)) ? dt_format_text($dt_start, $api_timezone) : "";
@@ -546,7 +552,7 @@ function do_purge_tweets(array $querybin, $dt_start, $dt_end)
 
     // Show result
 
-    $response_mediatype = choose_mediatype(['application/json', 'text/html']);
+    $response_mediatype = choose_mediatype(['application/json', 'text/html', 'text/plain']);
 
     switch ($response_mediatype) {
         case 'application/json':
@@ -596,6 +602,7 @@ END;
             html_end();
             break;
 
+        case 'text/plain':
         default:
             print("{$num_del['tweets']} tweets purged from {$querybin['bin']}\n");
             foreach ($num_del as $name => $num) {

--- a/api/querybin.php
+++ b/api/querybin.php
@@ -222,11 +222,28 @@ function do_view_or_export_tweets(array $querybin, $dt_start, $dt_end, $export)
                 $dt_start->setTimezone($utc_tz);
                 $qparams .= '&startdate=';
                 $qparams .= urlencode($dt_start->format(DT_PARAM_PATTERN));
+            } else {
+                // Explicitly set startdate when there is none.
+                // This is probably unnecessary, but is done to mirror
+                // setting enddate explicitly (see below).
+                $min_t = dt_from_utc($querybin['mintime']);
+                $min_t->setTimezone($utc_tz);
+                $qparams .= '&startdate=';
+                $qparams .= urlencode($min_t->format(DT_PARAM_PATTERN));
             }
             if (isset($dt_end)) {
                 $dt_end->setTimezone($utc_tz);
                 $qparams .= '&enddate=';
                 $qparams .= urlencode($dt_end->format(DT_PARAM_PATTERN));
+            } else {
+                // Explicitly set enddate to maximum captured tweet time.
+                // This is necessary, because the export feature does not
+                // correctly infer the enddate when none is supplied:
+                // resulting in less tweets exported than expected.
+                $max_t = dt_from_utc($querybin['maxtime']);
+                $max_t->setTimezone($utc_tz);
+                $qparams .= '&enddate=';
+                $qparams .= urlencode($max_t->format(DT_PARAM_PATTERN));
             }
             if ($response_mediatype == 'text/tab-separated-values') {
                 $qparams .= '&outputformat=tsv';


### PR DESCRIPTION
A few minor enhancements to the APIs.

1. Added JSON representations for the two operations that didn't support it. This consistency makes the API easy to use/document, since we don't have to remember which operations support JSON and which don't.

2. Added plain text representations for all the operations. The code was there already (to support invoking the scripts from the command line) so it wasn't much effort to also support "text/plain" when invoked by HTTP. Might be useful when using _curl_ from a remote machine, to get the same results as invoking the PHP script from the command line on the server machine.

3. Added extra error checking to raise an error when `startdate` or `enddate` query parameters are provided in the HTTP request, but are not relevant to the operation being performed. This is better than silently ignoring the parameter(s), since the user has probably does something unexpected/wrong by supplying them.

The API has now been documented on the [wiki](https://github.com/digitalmethodsinitiative/dmi-tcat/wiki/API).

As usual, the pull request can be tested by explicitly installing its repository/branch for testing:

    ./tcat-install-linux.sh -R https://github.com/hoylen/dmi-tcat.git -B restful-api-enhancements  -l -c myconfig.cfg

_P.S. This is probably going to be my last contribution. Other API operations can be added to make the APIs more useful, but I suggest getting DMI-TCAT working with PHP7 should be the main priority before adding more functionality; that will also get rid of the "deprecated function" warnings to improve the signal-to-noise ratio of the logs and make debugging more easy._