### PR TITLE
Admin auth support for multi-user

### DIFF
--- a/analysis/index.php
+++ b/analysis/index.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../common/functions.php';
 require_once __DIR__ . '/common/config.php';
 require_once __DIR__ . '/common/functions.php';
 ?>

--- a/analysis/index.php
+++ b/analysis/index.php
@@ -159,7 +159,7 @@ if (defined('ANALYSIS_URL'))
                 <a href="https://github.com/digitalmethodsinitiative/dmi-tcat/issues?state=open" target="_blank" class="if_toplinks">issues</a>
                 <a href="https://github.com/digitalmethodsinitiative/dmi-tcat/wiki" target="_blank" class="if_toplinks">FAQ</a>
                 <?php
-                if (defined("ADMIN_USER") && ADMIN_USER != "" && isset($_SERVER['PHP_AUTH_USER']) && $_SERVER['PHP_AUTH_USER'] == ADMIN_USER)
+                if (is_admin())
                     print '<a href="../capture/index.php" class="if_toplinks">admin</a>';
                 ?>
             </div>

--- a/capture/common/form.trackgeophrases.php
+++ b/capture/common/form.trackgeophrases.php
@@ -1,8 +1,9 @@
 <?php
 include_once __DIR__ . '/../../config.php';
 include_once __DIR__ . '/../../common/constants.php';
+include_once __DIR__ . '/../../common/functions.php';
 
-if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
+if (!is_admin())
     die("Go away, you evil hacker!");
 ?>
 
@@ -24,4 +25,3 @@ if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER
     <br/><br/>
     Example bounding box for San Francisco: -122.75,36.8,-121.75,37.8
 </div>
-

--- a/capture/common/form.trackphrases.php
+++ b/capture/common/form.trackphrases.php
@@ -1,8 +1,9 @@
 <?php
 include_once __DIR__ . '/../../config.php';
 include_once __DIR__ . '/../../common/constants.php';
+include_once __DIR__ . '/../../common/functions.php';
 
-if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
+if (!is_admin())
     die("Go away, you evil hacker!");
 ?>
 
@@ -22,4 +23,3 @@ if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER
     <br/>
     Example bin: globalwarming,global warming,'climate change'
 </div>
-

--- a/capture/index.php
+++ b/capture/index.php
@@ -1,8 +1,9 @@
 <?php
 include_once __DIR__ . '/../config.php';
 include_once __DIR__ . '/../common/constants.php';
+include_once __DIR__ . '/../common/functions.php';
 
-if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
+if (!is_admin())
     die("Go away, you evil hacker!");
 
 include_once __DIR__ . '/query_manager.php';

--- a/capture/public/form.trackgeophrases.php
+++ b/capture/public/form.trackgeophrases.php
@@ -1,8 +1,9 @@
 <?php
 include_once __DIR__ . '/../../config.php';
 include_once __DIR__ . '/../../common/constants.php';
+include_once __DIR__ . '/../../common/functions.php';
 
-if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
+if (!is_admin())
     die("Go away, you evil hacker!");
 ?>
 
@@ -24,4 +25,3 @@ if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER
     <br/><br/>
     Example bounding box for San Francisco: -122.75,36.8,-121.75,37.8
 </div>
-

--- a/capture/public/form.trackphrases.php
+++ b/capture/public/form.trackphrases.php
@@ -1,8 +1,9 @@
 <?php
 include_once __DIR__ . '/../../config.php';
 include_once __DIR__ . '/../../common/constants.php';
+include_once __DIR__ . '/../../common/functions.php';
 
-if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
+if (!is_admin())
     die("Go away, you evil hacker!");
 ?>
 
@@ -22,4 +23,3 @@ if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER
     <br/>
     Example bin: globalwarming,global warming,'climate change'
 </div>
-

--- a/capture/query_manager.php
+++ b/capture/query_manager.php
@@ -2,8 +2,9 @@
 
 include_once __DIR__ . '/../config.php';
 include_once __DIR__ . '/../common/constants.php';
+include_once __DIR__ . '/../common/functions.php';
 
-if (defined(ADMIN_USER) && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER))
+if (!is_admin())
     die("Go away, you evil hacker!");
 
 include_once __DIR__ . '/../common/functions.php';

--- a/common/functions.php
+++ b/common/functions.php
@@ -27,11 +27,26 @@ function dbserver_has_utf8mb4_support() {
 }
 
 function is_admin(){
-    // Allow ADMIN_USER to be an array so multiple users can be "admin"
-    if(defined("ADMIN_USER") && is_array(ADMIN_USER) && sizeof(ADMIN_USER) > 0){
-        return (isset($_SERVER['PHP_AUTH_USER']) && in_array($_SERVER['PHP_AUTH_USER'], ADMIN_USER));
+
+    if(defined("ADMIN_USER") && ADMIN_USER != "")
+    {
+        $admin_users = @unserialize(ADMIN_USER);
+
+        // Support the old config style where ADMIN_USER can be a single string
+        if($admin_users === false){
+            $admin_users = array(ADMIN_USER);
+        }
+
+        // If there are no users set in ADMIN_USER then everyone is an admin
+        if(count($admin_users) == 0 || count($admin_users) == 1 && $admin_users[0] == ''){
+          return true;
+        }
+
+        return (isset($_SERVER['PHP_AUTH_USER']) && in_array($_SERVER['PHP_AUTH_USER'], $admin_users));
     }
-    return (defined("ADMIN_USER") && ADMIN_USER != "" && isset($_SERVER['PHP_AUTH_USER']) && $_SERVER['PHP_AUTH_USER'] == ADMIN_USER);
+
+    // If ADMIN_USER is empty so everyone is an admin
+    return true;
 }
 
 ?>

--- a/common/functions.php
+++ b/common/functions.php
@@ -26,4 +26,12 @@ function dbserver_has_utf8mb4_support() {
     return false;
 }
 
+function is_admin(){
+    // Allow ADMIN_USER to be an array so multiple users can be "admin"
+    if(defined("ADMIN_USER") && is_array(ADMIN_USER) && sizeof(ADMIN_USER) > 0){
+        return (isset($_SERVER['PHP_AUTH_USER']) && in_array($_SERVER['PHP_AUTH_USER'], ADMIN_USER));
+    }
+    return (defined("ADMIN_USER") && ADMIN_USER != "" && isset($_SERVER['PHP_AUTH_USER']) && $_SERVER['PHP_AUTH_USER'] == ADMIN_USER);
+}
+
 ?>

--- a/config.php.example
+++ b/config.php.example
@@ -18,19 +18,11 @@ $hostname = "localhost";
 define('CAPTUREROLES', serialize(array('track')));
 
 /*
- * The user who can add and modify query bins. 
+ * The user(s) who can add and modify query bins. 
  * This user should exist in your htaccess authentication
  * Leave empty if you do not want to restrict access to the query manager - which, of course, is a security risk
  */
-define('ADMIN_USER', 'admin');
-
-/*
- * Same as above, but allows you to define multiple Admin users
- * This is an alternate to the define above and requires PHP >= 5.6.
- * To use this, comment the define above and uncomment the const below
- * The users listed below should exist in your htaccess authentication
- */
-//const ADMIN_USER = array('admin', 'admin2');
+ define('ADMIN_USER', serialize(array('admin', 'admin2')));
 
 /*
  * *Super advanced and currently undocumented feature, leave settings as they are*

--- a/config.php.example
+++ b/config.php.example
@@ -25,6 +25,14 @@ define('CAPTUREROLES', serialize(array('track')));
 define('ADMIN_USER', 'admin');
 
 /*
+ * Same as above, but allows you to define multiple Admin users
+ * This is an alternate to the define above and requires PHP >= 5.6.
+ * To use this, comment the define above and uncomment the const below
+ * The users listed below should exist in your htaccess authentication
+ */
+//const ADMIN_USER = array('admin', 'admin2');
+
+/*
  * *Super advanced and currently undocumented feature, leave settings as they are*
  * We have made it possible to tunnel Twitter API connections through other hosts (obtaining a different source IP address), and use multiple keysets for multiple streaming queries.
  * Each capture script should define its role, see define('CAPTUREROLES',serialize(array()))

--- a/helpers/export.php
+++ b/helpers/export.php
@@ -48,7 +48,7 @@ require_once __DIR__ . '/../capture/common/functions.php';
 global $dbuser, $dbpass, $database, $hostname;
 
 if (!env_is_cli()) {
-    if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER)) {
+    if (!is_admin()) {
         die("Go away, you evil hacker!\n");
     } else {
         die("Please run this script only from the command-line.\n");

--- a/helpers/import.php
+++ b/helpers/import.php
@@ -20,7 +20,7 @@ require_once __DIR__ . '/../capture/common/functions.php';
 global $dbuser, $dbpass, $database, $hostname;
 
 if (!env_is_cli()) {
-    if (defined("ADMIN_USER") && ADMIN_USER != "" && (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] != ADMIN_USER)) {
+    if (!is_admin()) {
         die("Go away, you evil hacker!\n");
     } else {
         die("Please run this script only from the command-line.\n");


### PR DESCRIPTION
In order to support multiple admin users I created a new optionally enabled config that supports an array of users that are admins. It requires PHP 5.6 to assign an array to a constant though, so I commented about this in the example config. By default the single admin user config is on, and the new array is commented out.

I also centralized the admin check into common/functions.php with a new function is_admin(). This makes it so the code for checking if the user is an admin only exists in once place instead of everywhere it's needed. 