### PR TITLE
Constrained new query bin name length to a maximum length

### DIFF
--- a/capture/index.php
+++ b/capture/index.php
@@ -739,6 +739,10 @@ foreach ($bins as $id => $bin)
             alert("bin names can only consist of alpha-numeric characters and underscores")
             return false;
         }
+        if(binname.length > 45) {
+            alert("Bin names must be shorter than 45 characters in length (you entered " + binname.length +")");
+            return false;
+        }
         return true;
     }
             

--- a/capture/index.php
+++ b/capture/index.php
@@ -200,7 +200,7 @@ $lastRateLimitHit = getLastRateLimitHit();
                         <div class="if_row">
                             <div class='if_row_header'>Bin name:</div>
                             <div class='if_row_content'>
-                                <input id="newbin_name" name="newbin_name" type="text"/>
+                                <input id="newbin_name" name="newbin_name" type="text" maxlength="45"/>
                             </div>
                         </div>
 <?php if (array_search('track', $captureroles) !== false) { ?>


### PR DESCRIPTION
A quickfix as close to the user as possible by just disallowing interactive query lengths longer than a constant, plus also amended the `validateBin()` to complain and reject such a case. Fixes #280. User might still post who knows what if they are not using the HTML+JS UI.