### PR TITLE
Added an index for tweet_id in the _media tables for new bins. Fixes #299

### DIFF
--- a/capture/common/functions.php
+++ b/capture/common/functions.php
@@ -281,6 +281,7 @@ function create_bin($bin_name, $dbh = false) {
             `indice_start` int(11),
             `indice_end` int(11),
             PRIMARY KEY (`id`, `tweet_id`),
+                    KEY `tweet_id` (`tweet_id`),
                     KEY `media_url_https` (`media_url_https`),
                     KEY `media_type` (`media_type`),
                     KEY `photo_size_width` (`photo_size_width`),


### PR DESCRIPTION
Solves the issue for new bins, by considerably speeding up the

    SELECT * FROM the_bin_name_media WHERE tweet_id = 916039373991361504

queries which are done from [`mod.export_tweets.php`](https://github.com/digitalmethodsinitiative/dmi-tcat/blob/3c6715f69ffc7394e25b2be8ab9fe2317d51f577/analysis/mod.export_tweets.php#L90) to look up fields from the media table.

Does not solve the issue with already existing bins, for which the same index must be created. I wrote following Python program (improvements welcome of course), but am unsure how to best contribute something similar to TCAT:

```python
"""
Add tweet_id indices to a TCAT database so that export can feasibly be
done with additional fields.
"""

import logging
import sqlalchemy

CONNECTION = "mysql://username:password@hostname/database"

def add_index(table, engine):
    """Add the tweet_id index for table table."""
    if 'tweet_id' not in [idx.name for idx in table.indexes]:
        mindex = sqlalchemy.Index('tweet_id', table.c.tweet_id)
        logging.info("Indexing %s", table)
        return mindex.create(engine)

    logging.info("Already exists for %s", table)
    return None


def add_indices(suffix):
    """Add indices for all tables which have the suffix suffix."""
    logging.info("Adding indices")
    engine = sqlalchemy.create_engine(CONNECTION)
    results = []
    for table_name in engine.table_names():
        if table_name.endswith(suffix):
            meta = sqlalchemy.MetaData()
            table = sqlalchemy.Table(table_name, meta, autoload=True, autoload_with=engine)
            results.append(add_index(table, engine))
    return results


if __name__ == "__main__":
    logging.getLogger().setLevel(logging.INFO)
    print(add_indices("_media"))
    print(add_indices("_mentions"))
    print(add_indices("_hashtags"))
```