### PR TITLE
Attempt to make bin removal and info lookup more robust.

### DIFF
--- a/capture/query_manager.php
+++ b/capture/query_manager.php
@@ -182,71 +182,77 @@ function remove_bin($params) {
         $bin_name = $results['querybin'];
     }
 
-    // delete tcat_query_bin table
-    $sql = "DELETE FROM tcat_query_bins WHERE id = :id";
-    $delete_querybin = $dbh->prepare($sql);
-    $delete_querybin->bindParam(':id', $bin_id, PDO::PARAM_INT);
-    $delete_querybin->execute();
+    $dbh->beginTransaction();
+    try {
+        // delete tcat_query_bin table
+        $sql = "DELETE FROM tcat_query_bins WHERE id = :id";
+        $delete_querybin = $dbh->prepare($sql);
+        $delete_querybin->bindParam(':id', $bin_id, PDO::PARAM_INT);
+        $delete_querybin->execute();
 
-    // delete periods associated with the query bin
-    $sql = "DELETE FROM tcat_query_bins_periods WHERE querybin_id = :id";
-    $delete_querybin_periods = $dbh->prepare($sql);
-    $delete_querybin_periods->bindParam(':id', $bin_id, PDO::PARAM_INT);
-    $delete_querybin_periods->execute();
+        // delete periods associated with the query bin
+        $sql = "DELETE FROM tcat_query_bins_periods WHERE querybin_id = :id";
+        $delete_querybin_periods = $dbh->prepare($sql);
+        $delete_querybin_periods->bindParam(':id', $bin_id, PDO::PARAM_INT);
+        $delete_querybin_periods->execute();
 
-    // delete phrase references associated with the query bin
-    $sql = "DELETE FROM tcat_query_bins_phrases WHERE querybin_id = :id";
-    $delete_query_bins_phrases = $dbh->prepare($sql);
-    $delete_query_bins_phrases->bindParam(":id", $bin_id, PDO::PARAM_INT);
-    $delete_query_bins_phrases->execute();
+        // delete phrase references associated with the query bin
+        $sql = "DELETE FROM tcat_query_bins_phrases WHERE querybin_id = :id";
+        $delete_query_bins_phrases = $dbh->prepare($sql);
+        $delete_query_bins_phrases->bindParam(":id", $bin_id, PDO::PARAM_INT);
+        $delete_query_bins_phrases->execute();
 
-    // delete orphaned phrases
-    $sql = "DELETE FROM tcat_query_phrases where id not in ( select phrase_id from tcat_query_bins_phrases )";
-    $delete_query_phrases = $dbh->prepare($sql);
-    $delete_query_phrases->execute();
+        // delete orphaned phrases
+        $sql = "DELETE FROM tcat_query_phrases where id not in ( select phrase_id from tcat_query_bins_phrases )";
+        $delete_query_phrases = $dbh->prepare($sql);
+        $delete_query_phrases->execute();
 
-    // delete user references associated with the query bin
-    $sql = "DELETE FROM tcat_query_bins_users WHERE querybin_id = :id";
-    $delete_query_bins_users = $dbh->prepare($sql);
-    $delete_query_bins_users->bindParam(":id", $bin_id, PDO::PARAM_INT);
-    $delete_query_bins_users->execute();
+        // delete user references associated with the query bin
+        $sql = "DELETE FROM tcat_query_bins_users WHERE querybin_id = :id";
+        $delete_query_bins_users = $dbh->prepare($sql);
+        $delete_query_bins_users->bindParam(":id", $bin_id, PDO::PARAM_INT);
+        $delete_query_bins_users->execute();
 
-    // delete orphaned users
-    $sql = "DELETE FROM tcat_query_users where id not in ( select user_id from tcat_query_bins_users )";
-    $delete_query_users = $dbh->prepare($sql);
-    $delete_query_users->execute();
+        // delete orphaned users
+        $sql = "DELETE FROM tcat_query_users where id not in ( select user_id from tcat_query_bins_users )";
+        $delete_query_users = $dbh->prepare($sql);
+        $delete_query_users->execute();
 
-    $sql = "DROP TABLE " . $bin_name . "_tweets";
-    $delete_table = $dbh->prepare($sql);
-    $delete_table->execute();
+        $sql = "DROP TABLE " . $bin_name . "_tweets";
+        $delete_table = $dbh->prepare($sql);
+        $delete_table->execute();
 
-    $sql = "DROP TABLE " . $bin_name . "_mentions";
-    $delete_table = $dbh->prepare($sql);
-    $delete_table->execute();
+        $sql = "DROP TABLE " . $bin_name . "_mentions";
+        $delete_table = $dbh->prepare($sql);
+        $delete_table->execute();
 
-    $sql = "DROP TABLE " . $bin_name . "_hashtags";
-    $delete_table = $dbh->prepare($sql);
-    $delete_table->execute();
+        $sql = "DROP TABLE " . $bin_name . "_hashtags";
+        $delete_table = $dbh->prepare($sql);
+        $delete_table->execute();
 
-    $sql = "DROP TABLE " . $bin_name . "_urls";
-    $delete_table = $dbh->prepare($sql);
-    $delete_table->execute();
+        $sql = "DROP TABLE " . $bin_name . "_urls";
+        $delete_table = $dbh->prepare($sql);
+        $delete_table->execute();
 
-    $sql = "DROP TABLE " . $bin_name . "_withheld";
-    $delete_table = $dbh->prepare($sql);
-    $delete_table->execute();
+        $sql = "DROP TABLE " . $bin_name . "_withheld";
+        $delete_table = $dbh->prepare($sql);
+        $delete_table->execute();
 
-    $sql = "DROP TABLE " . $bin_name . "_places";
-    $delete_table = $dbh->prepare($sql);
-    $delete_table->execute();
+        $sql = "DROP TABLE " . $bin_name . "_places";
+        $delete_table = $dbh->prepare($sql);
+        $delete_table->execute();
 
-    $sql = "DROP TABLE " . $bin_name . "_media";
-    $delete_table = $dbh->prepare($sql);
-    $delete_table->execute();
+        $sql = "DROP TABLE " . $bin_name . "_media";
+        $delete_table = $dbh->prepare($sql);
+        $delete_table->execute();
 
-    echo '{"msg":"Query bin [' . $bin_name . ']has been deleted"}';
+        $dbh->commit();
 
-    $dbh = false;
+        echo '{"msg":"Query bin [' . $bin_name . ']has been deleted"}';
+    } catch (PDOException $e) {
+        error_log("Unable to remove bin '" . $bin_name . "': " . $e->getMessage());
+        $dbh->rollBack();
+    }
 }
 
 function pause_bin($params) {
@@ -774,9 +780,14 @@ function getBins() {
         $querybins[$bin->id]->nrOfTweets = 0;
         $sql = "SELECT count(id) AS count FROM " . $bin->name . "_tweets";
         $res = $dbh->prepare($sql);
-        if ($res->execute() && $res->rowCount()) {
-            $result = $res->fetch();
-            $querybins[$bin->id]->nrOfTweets = $result['count'];
+        try {
+            if ($res->execute() && $res->rowCount()) {
+                $result = $res->fetch();
+                $querybins[$bin->id]->nrOfTweets = $result['count'];
+            }
+        } catch (PDOException $e) {
+            error_log("Error retrieving tweet info for bin '" . $bin->name . "': " . $e->getMessage());
+            unset($querybins[$bin->id]);
         }
     }
     $dbh = false;


### PR DESCRIPTION
Sometimes deleting large query bins can fail or timeout, removing the tweet tables but not the entry from the bins table. This only seems to happen sporadically and is difficult to reproduce, but it results in the app crashing when accessing the capture page. The only fix is to manually remove the leftover bin row from the `tcat_query_bins` table.

This change attempts to prevent this by a) putting deletion operations in a single transaction and b) catching errors when retrieving bin info. The latter change is required because MySQL does not do schema changes such as table deletion in transactions so the problem with incomplete bin removal can still occur.