### PR TITLE
Sanitize query bin comments 

### DIFF
--- a/capture/query_manager.php
+++ b/capture/query_manager.php
@@ -52,7 +52,6 @@ function create_new_bin($params) {
         echo '{"msg":"This capturing type is not defined in the config file"}';
         return;
     }
-    // $comments = trim($params['newbin_comments']);
     $comments = sanitize_comments($params['newbin_comments']);
 
     // check whether the main query management tables are there, if not, create
@@ -426,10 +425,11 @@ function rename_bin($params) {
 
 function modify_bin_comments($querybin_id, $params) {
     $dbh = pdo_connect();
+    $comments = sanitize_comments($params['comments']);
     $sql = "UPDATE tcat_query_bins SET comments = :comments WHERE id = :querybin_id";
     $rec = $dbh->prepare($sql);
     $rec->bindParam(":querybin_id", $querybin_id, PDO::PARAM_INT);
-    $rec->bindParam(":comments", $params['comments'], PDO::PARAM_STR);
+    $rec->bindParam(":comments", $comments, PDO::PARAM_STR);
     $rec->execute();
     $dbh = false;
     echo '{"msg": "The comments have been modified"}';
@@ -570,9 +570,13 @@ function array_trim_and_unique($array) {
 }
 
 function sanitize_comments($comments) {
-    $comments = trim($comments);
-    $comments = filter_var($comments, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-    return $comments;
+    try {
+        $comments = trim($comments);
+        $comments = htmlspecialchars($comments, ENT_QUOTES);
+        return $comments;
+    } catch (Exception $e) {
+        throw $e;
+    }
 }
 
 function get_phrases_from_geoquery($query) {

--- a/capture/query_manager.php
+++ b/capture/query_manager.php
@@ -52,7 +52,8 @@ function create_new_bin($params) {
         echo '{"msg":"This capturing type is not defined in the config file"}';
         return;
     }
-    $comments = trim($params['newbin_comments']);
+    // $comments = trim($params['newbin_comments']);
+    $comments = sanitize_comments($params['newbin_comments']);
 
     // check whether the main query management tables are there, if not, create
     create_admin();
@@ -566,6 +567,12 @@ function array_trim_and_unique($array) {
             $array[$k] = $v;
     }
     return $array;
+}
+
+function sanitize_comments($comments) {
+    $comments = trim($comments);
+    $comments = filter_var($comments, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+    return $comments;
 }
 
 function get_phrases_from_geoquery($query) {

--- a/tests/capture/sanitize_commentsTest.php
+++ b/tests/capture/sanitize_commentsTest.php
@@ -74,4 +74,24 @@ class Test_sanitize_comments extends TestCase
         $this->expectException(PHPUnit\Framework\Error\Error::class);
         sanitize_comments($input);
     }
+
+    /**
+     * Example case from
+     * https://github.com/digitalmethodsinitiative/dmi-tcat/issues/350
+     */
+    public function testReportedCommentWithEmailShouldBeEncoded() {
+        $input = 'A query for Firstname Lastname <firstname.lastname@instituti.on>, expected to run until 2019-02-28. set up by Mace Ojala on 2018-11-27';
+        $this->assertEquals(sanitize_comments($input), 'A query for Firstname Lastname &lt;firstname.lastname@instituti.on&gt;, expected to run until 2019-02-28. set up by Mace Ojala on 2018-11-27');
+    }
+
+    /**
+     * Example case from
+     * https://github.com/digitalmethodsinitiative/dmi-tcat/issues/350
+     * . I have not properly thought about and investigated very hard
+     * where the problem with this one actually is.
+     */
+    public function testReportedCommentWithDanishShouldFine() {
+        $input = 'helse tværspor added 23-04-2017 (JMB)';
+        $this->assertEquals(sanitize_comments($input), $input);
+    }
 }

--- a/tests/capture/sanitize_commentsTest.php
+++ b/tests/capture/sanitize_commentsTest.php
@@ -7,13 +7,13 @@ require_once __DIR__ . '../../../capture/query_manager.php';
 
 class Test_sanitize_comments extends TestCase
 {
-    public function testEmptyCommentShouldPass()
+    public function testEmptyCommentShouldBeFine()
     {
         $input = '';
         $this->assertEquals(sanitize_comments($input), '');
     }
 
-    public function testShortCommentShouldPass() {
+    public function testShortCommentShouldBeFine() {
         $input = 'A short comment.';
         $this->assertEquals(sanitize_comments($input), 'A short comment.');
     }
@@ -23,7 +23,7 @@ class Test_sanitize_comments extends TestCase
         $this->assertEquals(sanitize_comments($input), 'Has leading space.');
     }
 
-    public function testCommentWithTrailingSpaceShouldBeTrimmer() {
+    public function testCommentWithTrailingSpaceShouldBeTrimmed() {
         $input = 'Has trailing space. ';
         $this->assertEquals(sanitize_comments($input), 'Has trailing space.');
     }
@@ -40,7 +40,7 @@ class Test_sanitize_comments extends TestCase
 
     public function testHtmlEntityShouldBeEncoded() {
         $input = 'This &lt; is already encoded';
-        $this->assertEquals(sanitize_comments($input), 'This &lt; is already encoded');
+        $this->assertEquals(sanitize_comments($input), 'This &amp;lt; is already encoded');
     }
 
     public function testCommentWithAmpersandShouldBeEncoded() {
@@ -56,5 +56,22 @@ class Test_sanitize_comments extends TestCase
     public function testCommentWithSingleQuoteShouldBeEncoded() {
         $input = 'A \'clever\' comment';
         $this->assertEquals(sanitize_comments($input), 'A &#039;clever&#039; comment');
+    }
+
+    public function testCommentOutsideLatin1ShouldBeFine() {
+        $input = 'It is 2019, øæøæøæ is fine';
+        $this->assertEquals(sanitize_comments($input), $input);
+    }
+
+    public function testCommentWithEmojiShouldBeFine() {
+        // Hoping the database is UTF-8, of course
+        $input = 'It is 2019, 🦄 is fine in comments. What a time to be alive';
+        $this->assertEquals(sanitize_comments($input), $input);
+    }
+
+    public function testCommentArrayShouldThrowTypeException() {
+        $input = [];
+        $this->expectException(PHPUnit\Framework\Error\Error::class);
+        sanitize_comments($input);
     }
 }

--- a/tests/capture/sanitize_commentsTest.php
+++ b/tests/capture/sanitize_commentsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+define('CAPTUREROLES', serialize(array('track')));
+require_once __DIR__ . '../../../capture/query_manager.php';
+
+class Test_sanitize_comments extends TestCase
+{
+    public function testEmptyCommentShouldPass()
+    {
+        $input = '';
+        $this->assertEquals(sanitize_comments($input), '');
+    }
+
+    public function testShortCommentShouldPass() {
+        $input = 'A short comment.';
+        $this->assertEquals(sanitize_comments($input), 'A short comment.');
+    }
+
+    public function testCommentWithLeadingSpaceShouldBeTrimmed() {
+        $input = ' Has leading space.';
+        $this->assertEquals(sanitize_comments($input), 'Has leading space.');
+    }
+
+    public function testCommentWithTrailingSpaceShouldBeTrimmer() {
+        $input = 'Has trailing space. ';
+        $this->assertEquals(sanitize_comments($input), 'Has trailing space.');
+    }
+
+    public function testCommentWithLessThanShouldBeEncoded() {
+        $input = 'This comment has < relevance than some';
+        $this->assertEquals(sanitize_comments($input), 'This comment has &lt; relevance than some');
+    }
+
+    public function testCommentWithGreaterThanShouldBeEncoded() {
+        $input = 'This :> is perhaps my favourite smilie';
+        $this->assertEquals(sanitize_comments($input), 'This :&gt; is perhaps my favourite smilie');
+    }
+
+    public function testHtmlEntityShouldBeEncoded() {
+        $input = 'This &lt; is already encoded';
+        $this->assertEquals(sanitize_comments($input), 'This &lt; is already encoded');
+    }
+
+    public function testCommentWithAmpersandShouldBeEncoded() {
+        $input = 'The & is not a boolean conjunction in TCAT';
+        $this->assertEquals(sanitize_comments($input), 'The &amp; is not a boolean conjunction in TCAT');
+    }
+
+    public function testCommentWithDoubleQuoteShouldBeEncoded() {
+        $input = 'This is one of those "great" bins';
+        $this->assertEquals(sanitize_comments($input), 'This is one of those &quot;great&quot; bins');
+    }
+
+    public function testCommentWithSingleQuoteShouldBeEncoded() {
+        $input = 'A \'clever\' comment';
+        $this->assertEquals(sanitize_comments($input), 'A &#039;clever&#039; comment');
+    }
+}


### PR DESCRIPTION
I decided to place the boundary of input sanitization at the level where user input is being transferred from the HTTP request to bin creation and modification parameters.

This provides only some unit test, not any integration tests or testing what goes down to the database and what get's retrieved from it, or what the full user-agent to user-agent roundtrip through the stack is.

Database upgrade is missing at this point and existing comments remain problematic – I have not written a TCAT database migration before.