### PR TITLE
Get capture rate from the API

### DIFF
--- a/api/server.php
+++ b/api/server.php
@@ -177,25 +177,28 @@ function do_rate_info()
     $response_mediatype = choose_mediatype(['application/json', 'text/html',
                                             'text/plain']);
 
+    $notweets = 200000;
     $dbh = pdo_connect();
-
-    $sql = 'SELECT year(tcp.created_at) AS year,month(tcp.created_at) AS month, day(tcp.created_at) AS day,count(*) AS count FROM (SELECT * FROM tcat_captured_phrases ORDER BY created_at DESC LIMIT 50000) AS tcp GROUP BY year(tcp.created_at),month(created_at),day(tcp.created_at)';
+    $sql = 'SELECT date(t.created_at) AS date, count(*) AS count FROM (SELECT * FROM tcat_captured_phrases ORDER BY created_at DESC LIMIT 200000) AS t GROUP BY date(t.created_at)';
     $rec = $dbh->prepare($sql);
     $rec->execute();
     while ($res = $rec->fetch(PDO::FETCH_ASSOC)) {
-        //$rates[[res['year'][res['month']res['day']] = $res['count'];
-        $rates[$res['year']][$res['month']][$res['day']] = +$res['count'];
+        $rates[$res['date']] = $res['count'];
     }
-    // $rates = $rec->fetchAll();
 
     switch ($response_mediatype) {
         case 'application/json':
-            $obj = array ('rate' => $rates );
+            $obj = array('notweets' => $notweets, 'counts' => $rates);
             respond_with_json($obj);
             break;
         case 'text/html':
-            html_begin("Rate info here");
-            print($rates);
+            // html_begin("Rate info here", [["Rate information"]]);
+            echo "<table>";
+            echo "<tr><th>date</th><th>count</th></tr>";
+            foreach($rates as $date => $count) {
+                echo "<tr><td class='date'>$date</td><td class='count'>$count</tr>";
+            }
+            echo "</table>";
             html_end();
             break;
         case 'text/plain':

--- a/api/server.php
+++ b/api/server.php
@@ -188,11 +188,11 @@ function do_rate_info()
          'text/plain']
     );
 
-    $limit = 100000;
+    $days = 30;
     $dbh = pdo_connect();
-    $sql = 'SELECT date(t.created_at) AS date, count(*) AS count FROM (SELECT * FROM tcat_captured_phrases ORDER BY created_at DESC LIMIT :limit) AS t GROUP BY date(t.created_at)';
+    $sql = 'SELECT date(t.created_at) AS date, count(*) AS count FROM (SELECT * FROM tcat_captured_phrases WHERE created_at >= CURDATE() - INTERVAL :days DAY) AS t GROUP BY date(t.created_at)';
     $rec = $dbh->prepare($sql);
-    $rec->bindValue(':limit', $limit, PDO::PARAM_INT);
+    $rec->bindValue(':days', $days, PDO::PARAM_INT);
     $rec->execute();
     while ($res = $rec->fetch(PDO::FETCH_ASSOC)) {
         $rates[$res['date']] = +$res['count'];
@@ -200,7 +200,7 @@ function do_rate_info()
 
     switch ($response_mediatype) {
         case 'application/json':
-            $obj = array('limit' => $limit, 'counts' => $rates);
+            $obj = ['days' => $days, 'counts' => $rates];
             respond_with_json($obj);
             break;
         case 'text/html':

--- a/api/server.php
+++ b/api/server.php
@@ -188,11 +188,11 @@ function do_rate_info()
          'text/plain']
     );
 
-    $days = 30;
+    $days_back = 30;
     $dbh = pdo_connect();
-    $sql = 'SELECT date(t.created_at) AS date, count(*) AS count FROM (SELECT * FROM tcat_captured_phrases WHERE created_at >= CURDATE() - INTERVAL :days DAY) AS t GROUP BY date(t.created_at)';
+    $sql = 'SELECT date(t.created_at) AS date, count(*) AS count FROM (SELECT * FROM tcat_captured_phrases WHERE created_at >= CURDATE() - INTERVAL :days_back DAY) AS t GROUP BY date(t.created_at)';
     $rec = $dbh->prepare($sql);
-    $rec->bindValue(':days', $days, PDO::PARAM_INT);
+    $rec->bindValue(':days_back', $days_back, PDO::PARAM_INT);
     $rec->execute();
     while ($res = $rec->fetch(PDO::FETCH_ASSOC)) {
         $rates[$res['date']] = +$res['count'];
@@ -200,7 +200,7 @@ function do_rate_info()
 
     switch ($response_mediatype) {
         case 'application/json':
-            $obj = ['days' => $days, 'counts' => $rates];
+            $obj = ['days_back' => $days_back, 'counts' => $rates];
             respond_with_json($obj);
             break;
         case 'text/html':

--- a/api/server.php
+++ b/api/server.php
@@ -176,7 +176,7 @@ function do_ratelimit_info()
  *
  * @return void
  */
-function do_rate_info($report_missing_days = TRUE)
+function do_rate_info($report_missing_days = true)
 {
     global $datasets; // from require_once "../analysis/common/functions.php"
 
@@ -200,17 +200,19 @@ function do_rate_info($report_missing_days = TRUE)
         $rates[$res['date']] = +$res['count'];
     }
 
-    if($report_missing_days) {
+    if ($report_missing_days) {
         // Create an array of dates null value, and left merge it with the
         // rates from database. This way also empty days will be included
         // in the results and usefully reported.
         $dates = array();
-        foreach(iterator_to_array(
+        foreach (iterator_to_array(
             new DatePeriod(
                 new DateTime($days_back * -1 . ' days'),
                 new DateInterval('P1D'),
-                new DateTime)) as $date) {
-            $dates[$date->format('Y-m-d')] = NULL;
+                new DateTime
+            )
+        ) as $date) {
+            $dates[$date->format('Y-m-d')] = null;
         }
         $rates = array_merge($dates, $rates);
     }

--- a/api/server.php
+++ b/api/server.php
@@ -177,14 +177,25 @@ function do_rate_info()
     $response_mediatype = choose_mediatype(['application/json', 'text/html',
                                             'text/plain']);
 
+    $dbh = pdo_connect();
+
+    $sql = 'SELECT year(tcp.created_at) AS year,month(tcp.created_at) AS month, day(tcp.created_at) AS day,count(*) AS count FROM (SELECT * FROM tcat_captured_phrases ORDER BY created_at DESC LIMIT 50000) AS tcp GROUP BY year(tcp.created_at),month(created_at),day(tcp.created_at)';
+    $rec = $dbh->prepare($sql);
+    $rec->execute();
+    while ($res = $rec->fetch(PDO::FETCH_ASSOC)) {
+        //$rates[[res['year'][res['month']res['day']] = $res['count'];
+        $rates[$res['year']][$res['month']][$res['day']] = +$res['count'];
+    }
+    // $rates = $rec->fetchAll();
+
     switch ($response_mediatype) {
         case 'application/json':
-            // $obj = array( 'rate' => 'something here' );
-            $obj = array ('rate' => $datasets );
+            $obj = array ('rate' => $rates );
             respond_with_json($obj);
             break;
         case 'text/html':
             html_begin("Rate info here");
+            print($rates);
             html_end();
             break;
         case 'text/plain':

--- a/api/server.php
+++ b/api/server.php
@@ -177,7 +177,7 @@ function do_rate_info()
     $response_mediatype = choose_mediatype(['application/json', 'text/html',
                                             'text/plain']);
 
-    $notweets = 200000;
+    $limit = 200000;
     $dbh = pdo_connect();
     $sql = 'SELECT date(t.created_at) AS date, count(*) AS count FROM (SELECT * FROM tcat_captured_phrases ORDER BY created_at DESC LIMIT 200000) AS t GROUP BY date(t.created_at)';
     $rec = $dbh->prepare($sql);
@@ -188,7 +188,7 @@ function do_rate_info()
 
     switch ($response_mediatype) {
         case 'application/json':
-            $obj = array('notweets' => $notweets, 'counts' => $rates);
+            $obj = array('limit' => $limit, 'counts' => $rates);
             respond_with_json($obj);
             break;
         case 'text/html':

--- a/api/server.php
+++ b/api/server.php
@@ -162,6 +162,39 @@ function do_ratelimit_info()
 }
 
 //----------------------------------------------------------------
+// Display rate information for this server
+//
+// Returns variable for JSON output or title+html for HTML output.
+
+function do_rate_info()
+{
+    global $datasets; // from require_once "../analysis/common/functions.php"
+
+    if (!isset($datasets)) {
+        $datasets = []; // database tables not yet initialized
+    }
+
+    $response_mediatype = choose_mediatype(['application/json', 'text/html',
+                                            'text/plain']);
+
+    switch ($response_mediatype) {
+        case 'application/json':
+            $obj = array( 'rate' => 'something here' ); //$datasets );
+            respond_with_json($obj);
+            break;
+        case 'text/html':
+            html_begin("Rate info here");
+            html_end();
+            break;
+        case 'text/plain':
+        default:
+            // TODO
+            break;
+    }
+
+}
+
+//----------------------------------------------------------------
 // Main function
 //
 // This is a function to avoid unexpected clashes with global variables.
@@ -210,6 +243,8 @@ function main()
         } else {
             if (is_null($aspect)) {
                 $action = 'server-info';     // implicit action
+            } else if ($aspect == 'rateinfo') {
+                $action = 'rate-info';
             } else if ($aspect == 'ratelimits') {
                 $action = 'ratelimit-info';  // implicit action
             } else {
@@ -284,6 +319,9 @@ END;
             break;
         case 'ratelimit-info':
             do_ratelimit_info();
+            break;
+        case 'rate-info':
+            do_rate_info();
             break;
         default:
             abort_with_error(500, "Internal error: unexpected action: $action");

--- a/api/server.php
+++ b/api/server.php
@@ -172,11 +172,12 @@ function do_ratelimit_info()
  * Based on the tcat_captured_phrases table, and output format is
  * figured out from the HTTP request.
  *
+ * @param int  $days_back           Number of days of history to report.
  * @param bool $report_missing_days Explicitly report missing days.
  *
  * @return void
  */
-function do_rate_info($report_missing_days = true)
+function do_rate_info($days_back = 30, $report_missing_days = true)
 {
     global $datasets; // from require_once "../analysis/common/functions.php"
 
@@ -190,7 +191,6 @@ function do_rate_info($report_missing_days = true)
          'text/plain']
     );
 
-    $days_back = 30;
     $dbh = pdo_connect();
     $sql = 'SELECT date(t.created_at) AS date, count(*) AS count FROM (SELECT * FROM tcat_captured_phrases WHERE created_at >= CURDATE() - INTERVAL :days_back DAY) AS t GROUP BY date(t.created_at)';
     $rec = $dbh->prepare($sql);

--- a/api/server.php
+++ b/api/server.php
@@ -214,7 +214,10 @@ function do_rate_info()
             break;
         case 'text/plain':
         default:
-            // TODO
+            echo "date" . "," . "count" . PHP_EOL;
+            foreach ($rates as $date => $count) {
+                echo $date . "," . $count . PHP_EOL;
+            }
             break;
     }
 

--- a/api/server.php
+++ b/api/server.php
@@ -172,9 +172,11 @@ function do_ratelimit_info()
  * Based on the tcat_captured_phrases table, and output format is
  * figured out from the HTTP request.
  *
+ * @param bool $report_missing_days Explicitly report missing days.
+ *
  * @return void
  */
-function do_rate_info()
+function do_rate_info($report_missing_days = TRUE)
 {
     global $datasets; // from require_once "../analysis/common/functions.php"
 
@@ -198,18 +200,20 @@ function do_rate_info()
         $rates[$res['date']] = +$res['count'];
     }
 
-    // Create an array of dates null value, and left merge it with the
-    // rates from database. This way also empty days will be included
-    // in the results and usefully reported.
-    $dates = array();
-    foreach(iterator_to_array(
-        new DatePeriod(
-            new DateTime($days_back * -1 . ' days'),
-            new DateInterval('P1D'),
-            new DateTime)) as $date) {
-        $dates[$date->format('Y-m-d')] = NULL;
+    if($report_missing_days) {
+        // Create an array of dates null value, and left merge it with the
+        // rates from database. This way also empty days will be included
+        // in the results and usefully reported.
+        $dates = array();
+        foreach(iterator_to_array(
+            new DatePeriod(
+                new DateTime($days_back * -1 . ' days'),
+                new DateInterval('P1D'),
+                new DateTime)) as $date) {
+            $dates[$date->format('Y-m-d')] = NULL;
+        }
+        $rates = array_merge($dates, $rates);
     }
-    $rates = array_merge($dates, $rates);
 
     switch ($response_mediatype) {
         case 'application/json':

--- a/api/server.php
+++ b/api/server.php
@@ -183,7 +183,7 @@ function do_rate_info()
     $rec = $dbh->prepare($sql);
     $rec->execute();
     while ($res = $rec->fetch(PDO::FETCH_ASSOC)) {
-        $rates[$res['date']] = $res['count'];
+        $rates[$res['date']] = +$res['count'];
     }
 
     switch ($response_mediatype) {

--- a/api/server.php
+++ b/api/server.php
@@ -179,7 +179,8 @@ function do_rate_info()
 
     switch ($response_mediatype) {
         case 'application/json':
-            $obj = array( 'rate' => 'something here' ); //$datasets );
+            // $obj = array( 'rate' => 'something here' );
+            $obj = array ('rate' => $datasets );
             respond_with_json($obj);
             break;
         case 'text/html':

--- a/api/server.php
+++ b/api/server.php
@@ -198,6 +198,19 @@ function do_rate_info()
         $rates[$res['date']] = +$res['count'];
     }
 
+    // Create an array of dates null value, and left merge it with the
+    // rates from database. This way also empty days will be included
+    // in the results and usefully reported.
+    $dates = array();
+    foreach(iterator_to_array(
+        new DatePeriod(
+            new DateTime($days_back * -1 . ' days'),
+            new DateInterval('P1D'),
+            new DateTime)) as $date) {
+        $dates[$date->format('Y-m-d')] = NULL;
+    }
+    $rates = array_merge($dates, $rates);
+
     switch ($response_mediatype) {
         case 'application/json':
             $obj = ['days_back' => $days_back, 'counts' => $rates];


### PR DESCRIPTION
This PR extends the TCAT API, namely the `server.php` endpoint with new action `rate-info` which, depending on the HTTP request _Content-Type_ header, returns either a JSON or HTML representation of daily tweet capture counts for the past 30 days.

E.g. the request`curl -H 'Content-Type: application/json' 'https://tcatserver/dmi-tcat/api/server.php?action=rate-info'`

responds with
```json
{
   "days_back" : 30,
   "original_request" : {
      "GET" : {
         "action" : "rate-info"
      },
      "URI" : null,
      "POST" : [],
      "esc" : []
   },
   "counts" : {
      "2019-08-06" : 6501,
      "2019-08-12" : 12715,
      "2019-08-07" : 11813,
      "2019-08-14" : 7047,
      "2019-08-10" : 11611,
      "2019-08-09" : 12110,
      "2019-08-11" : 11423,
      "2019-08-13" : 14355,
      "2019-08-08" : 12212
   }
}
```
And for HTML output

![Screenshot 2019-08-14 at 17 37 23](https://user-images.githubusercontent.com/879300/63034845-4dcd3780-beba-11e9-8738-7e0916078a37.png).

A couple of further things to consider:

* Maybe accept the number of days as a parameter? Currently [it is hardcoded](https://github.com/xmacex/dmi-tcat/blob/1e42b1c29939cc9f86a69b7eed3a243dffb2378e/api/server.php#L191).
* Maybe provide a full list of dates, and a zero value for the count if none were captured?
* Would another JSON format be nicer?
* Would it make sense to redact the current day, since it isn't complete?
* Provide unit tests and/or integration tests.
* Update [the API documentation](https://github.com/digitalmethodsinitiative/dmi-tcat/wiki/API).

Closes #374. Comments more than welcome :)