### PR TITLE
Consider all DB-collations beginning w/ 'utf8mb4' to be utf8mb4 collations

### DIFF
--- a/analysis/common/functions.php
+++ b/analysis/common/functions.php
@@ -866,7 +866,7 @@ function current_collation() {
     $rec = $dbh->prepare($sql);
     $rec->execute();
     while ($res = $rec->fetch(PDO::FETCH_ASSOC)) {
-        if (array_key_exists('Collation', $res) && ($res['Collation'] == 'utf8mb4_unicode_ci' || $res['Collation'] == 'utf8mb4_general_ci')) {
+        if (array_key_exists('Collation', $res) && substr($res['Collation'], 0, 7) === 'utf8mb4') {
             $is_utf8mb4 = true;
             break;
         }

--- a/analysis/index.php
+++ b/analysis/index.php
@@ -21,8 +21,6 @@ require_once __DIR__ . '/common/functions.php';
 
         <script type="text/javascript">
 
-            google.load("visualization", "1", {packages:["corechart"]});
-
             function sendUrl(_file) {
                 var _d1 = $("#ipt_startdate").val();
                 var _d2 = $("#ipt_enddate").val();
@@ -501,17 +499,22 @@ if (defined('ANALYSIS_URL'))
 
                     <script type="text/javascript">
 
-                        var data = new google.visualization.DataTable();
-                        data.addColumn('string', 'Slice');
-                        data.addColumn('number', 'Percent');
-                        data.addRows(2);
-                        data.setValue(0, 0, 'Tweets containing links');
-                        data.setValue(0, 1, <?php echo $numlinktweets; ?>);
-                        data.setValue(1, 0, 'Tweets containing no links');
-                        data.setValue(1, 1, <?php echo $numtweets - $numlinktweets; ?>);
+                        google.load("visualization", "1", {packages:["corechart"]});
+                        google.setOnLoadCallback(drawPieChart);
 
-                        var chart = new google.visualization.PieChart(document.getElementById('if_panel_linkchart'));
-                        chart.draw(data, {width: 380, height: 160});
+                        function drawPieChart() {
+                            var data = new google.visualization.DataTable();
+                            data.addColumn('string', 'Slice');
+                            data.addColumn('number', 'Percent');
+                            data.addRows(2);
+                            data.setValue(0, 0, 'Tweets containing links');
+                            data.setValue(0, 1, <?php echo $numlinktweets; ?>);
+                            data.setValue(1, 0, 'Tweets containing no links');
+                            data.setValue(1, 1, <?php echo $numtweets - $numlinktweets; ?>);
+
+                            var chart = new google.visualization.PieChart(document.getElementById('if_panel_linkchart'));
+                            chart.draw(data, {width: 380, height: 160});
+                        }
 
                     </script>
 
@@ -530,33 +533,49 @@ if (defined('ANALYSIS_URL'))
 
                 <script type="text/javascript">
 
-                    var data = new google.visualization.DataTable();
+                    google.setOnLoadCallback(drawLineChart);
 
-                    data.addColumn('string', 'Date');
-                    data.addColumn('number', 'Tweets');
-                    data.addColumn('number', 'Users');
-                    data.addColumn('number', 'Locations');
-                    data.addColumn('number', 'Geo coded');
+                    function drawLineChart() {
+                        var data = new google.visualization.DataTable();
 
-<?php
-echo "data.addRows(" . count($linedata) . ");";
+                        data.addColumn('string', 'Date');
+                        data.addColumn('number', 'Tweets');
+                        data.addColumn('number', 'Users');
+                        data.addColumn('number', 'Locations');
+                        data.addColumn('number', 'Geo coded');
 
-$counter = 0;
+                        <?php
+                        echo "data.addRows(" . count($linedata) . ");";
 
-foreach ($linedata as $key => $value) {
+                        $counter = 0;
 
-    echo "data.setValue(" . $counter . ", 0, '" . $key . "');";
-    echo "data.setValue(" . $counter . ", 1, " . $value["tweets"] . ");";
-    echo "data.setValue(" . $counter . ", 2, " . $value["users"] . ");";
-    echo "data.setValue(" . $counter . ", 3, " . $value["locations"] . ");";
-    echo "data.setValue(" . $counter . ", 4, " . $value["geolocs"] . ");";
+                        foreach ($linedata as $key => $value) {
 
-    $counter++;
-}
-?>
+                            echo "data.setValue(" . $counter . ", 0, '" . $key . "');";
+                            echo "data.setValue(" . $counter . ", 1, " . $value["tweets"] . ");";
+                            echo "data.setValue(" . $counter . ", 2, " . $value["users"] . ");";
+                            echo "data.setValue(" . $counter . ", 3, " . $value["locations"] . ");";
+                            echo "data.setValue(" . $counter . ", 4, " . $value["geolocs"] . ");";
 
-    var chart = new google.visualization.LineChart(document.getElementById('if_panel_linegraph'));
-    chart.draw(data, {width:1000, height:390, fontSize:9, lineWidth:1, hAxis:{slantedTextAngle:90, slantedText:true}, chartArea:{left:50,top:10,width:850,height:300}});
+                            $counter++;
+                        }
+                        ?>
+
+                        var chart = new google.visualization.LineChart(document.getElementById('if_panel_linegraph'));
+                        chart.draw(data, {
+                            width: 1000,
+                            height: 390,
+                            fontSize: 9,
+                            lineWidth: 1,
+                            hAxis: {slantedTextAngle: 90, slantedText: true},
+                            chartArea: {
+                                left: 50,
+                                top: 10,
+                                width: 850,
+                                height: 300
+                            }
+                        })
+                    }
 
                 </script>
 


### PR DESCRIPTION
Instead of 'utf8mb4_unicode_ci' or 'utf8mb4_general_ci', the DB-collation in my MySQL 8.0.20-0ubuntu0.20.04.1. is 'utf8mb4_0900_ai_ci' (and there is a long list of other collations beginning with 'utf8mb4'). Function current_collation() thus returns 'utf8_bin', not 'utf8mb4_bin'.

The following error is thrown any time I try to launch any of the Networks analyzes: PHP Fatal error:  Uncaught PDOException: SQLSTATE[42000]: Syntax error or access violation: 1253 COLLATION 'utf8_bin' is not valid for CHARACTER SET 'utf8mb4' in /var/www/dmi-tcat/analysis/mod.mention_graph.php:56

The PR changes function current_collation() so that it considers all DB-collations beginning with string 'utf8mb4' to be an utf8mb4 collations, thus returning 'utf8mb4_bin'. Launching any of the Networks analyzes no longer throw an error.