### PR TITLE
Fix issue #401 - Google chart not displayed

### DIFF
--- a/analysis/index.php
+++ b/analysis/index.php
@@ -21,8 +21,6 @@ require_once __DIR__ . '/common/functions.php';
 
         <script type="text/javascript">
 
-            google.load("visualization", "1", {packages:["corechart"]});
-
             function sendUrl(_file) {
                 var _d1 = $("#ipt_startdate").val();
                 var _d2 = $("#ipt_enddate").val();
@@ -501,17 +499,22 @@ if (defined('ANALYSIS_URL'))
 
                     <script type="text/javascript">
 
-                        var data = new google.visualization.DataTable();
-                        data.addColumn('string', 'Slice');
-                        data.addColumn('number', 'Percent');
-                        data.addRows(2);
-                        data.setValue(0, 0, 'Tweets containing links');
-                        data.setValue(0, 1, <?php echo $numlinktweets; ?>);
-                        data.setValue(1, 0, 'Tweets containing no links');
-                        data.setValue(1, 1, <?php echo $numtweets - $numlinktweets; ?>);
+                        google.load("visualization", "1", {packages:["corechart"]});
+                        google.setOnLoadCallback(drawPieChart);
 
-                        var chart = new google.visualization.PieChart(document.getElementById('if_panel_linkchart'));
-                        chart.draw(data, {width: 380, height: 160});
+                        function drawPieChart() {
+                            var data = new google.visualization.DataTable();
+                            data.addColumn('string', 'Slice');
+                            data.addColumn('number', 'Percent');
+                            data.addRows(2);
+                            data.setValue(0, 0, 'Tweets containing links');
+                            data.setValue(0, 1, <?php echo $numlinktweets; ?>);
+                            data.setValue(1, 0, 'Tweets containing no links');
+                            data.setValue(1, 1, <?php echo $numtweets - $numlinktweets; ?>);
+
+                            var chart = new google.visualization.PieChart(document.getElementById('if_panel_linkchart'));
+                            chart.draw(data, {width: 380, height: 160});
+                        }
 
                     </script>
 
@@ -530,33 +533,49 @@ if (defined('ANALYSIS_URL'))
 
                 <script type="text/javascript">
 
-                    var data = new google.visualization.DataTable();
+                    google.setOnLoadCallback(drawLineChart);
 
-                    data.addColumn('string', 'Date');
-                    data.addColumn('number', 'Tweets');
-                    data.addColumn('number', 'Users');
-                    data.addColumn('number', 'Locations');
-                    data.addColumn('number', 'Geo coded');
+                    function drawLineChart() {
+                        var data = new google.visualization.DataTable();
 
-<?php
-echo "data.addRows(" . count($linedata) . ");";
+                        data.addColumn('string', 'Date');
+                        data.addColumn('number', 'Tweets');
+                        data.addColumn('number', 'Users');
+                        data.addColumn('number', 'Locations');
+                        data.addColumn('number', 'Geo coded');
 
-$counter = 0;
+                        <?php
+                        echo "data.addRows(" . count($linedata) . ");";
 
-foreach ($linedata as $key => $value) {
+                        $counter = 0;
 
-    echo "data.setValue(" . $counter . ", 0, '" . $key . "');";
-    echo "data.setValue(" . $counter . ", 1, " . $value["tweets"] . ");";
-    echo "data.setValue(" . $counter . ", 2, " . $value["users"] . ");";
-    echo "data.setValue(" . $counter . ", 3, " . $value["locations"] . ");";
-    echo "data.setValue(" . $counter . ", 4, " . $value["geolocs"] . ");";
+                        foreach ($linedata as $key => $value) {
 
-    $counter++;
-}
-?>
+                            echo "data.setValue(" . $counter . ", 0, '" . $key . "');";
+                            echo "data.setValue(" . $counter . ", 1, " . $value["tweets"] . ");";
+                            echo "data.setValue(" . $counter . ", 2, " . $value["users"] . ");";
+                            echo "data.setValue(" . $counter . ", 3, " . $value["locations"] . ");";
+                            echo "data.setValue(" . $counter . ", 4, " . $value["geolocs"] . ");";
 
-    var chart = new google.visualization.LineChart(document.getElementById('if_panel_linegraph'));
-    chart.draw(data, {width:1000, height:390, fontSize:9, lineWidth:1, hAxis:{slantedTextAngle:90, slantedText:true}, chartArea:{left:50,top:10,width:850,height:300}});
+                            $counter++;
+                        }
+                        ?>
+
+                        var chart = new google.visualization.LineChart(document.getElementById('if_panel_linegraph'));
+                        chart.draw(data, {
+                            width: 1000,
+                            height: 390,
+                            fontSize: 9,
+                            lineWidth: 1,
+                            hAxis: {slantedTextAngle: 90, slantedText: true},
+                            chartArea: {
+                                left: 50,
+                                top: 10,
+                                width: 850,
+                                height: 300
+                            }
+                        })
+                    }
 
                 </script>
 


### PR DESCRIPTION
Fix issue #401 - Google chart not displayed. Description: "The Tweet freqency line plot and url piechart are not displayed when one loads /var/www/dmi-tcat/analysis/index.php."

This appers to be a timing problem as described in here: https://stackoverflow.com/a/21660114
Also see: https://developers.google.com/chart/interactive/docs/basic_load_libs

I put the visualization code into new function drawPieChart() and drawLineChart() and call them with google.setOnLoadCallback(). This solves the problem and the charts are displayed fine.