### PR TITLE
Added cron to docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ logs
 proc
 .htaccess
 *~
+.idea/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 #
 FROM jrei/systemd-ubuntu:18.04
 
-RUN apt-get update
-RUN apt-get install -y lsb-release iproute2 sudo
+# Combine apt-get update and install per
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
+RUN apt-get update && apt-get install -y lsb-release iproute2 sudo cron
 
 #copy docker setup script
 COPY docker/setup.sh tcat-install-linux.sh
@@ -21,6 +22,5 @@ RUN /bin/bash ./tcat-install-linux.sh -y -c config.txt
 #expose port
 EXPOSE 80
 
-
 #start apache and mysql
-CMD sudo service mysql start && apachectl -D FOREGROUND
+CMD sudo service cron start && service mysql start && apachectl -D FOREGROUND

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,11 @@ RUN touch /etc/crontab
 RUN chmod a+x tcat-install-linux.sh
 RUN /bin/bash ./tcat-install-linux.sh -y -c config.txt
 
-
 #expose port
 EXPOSE 80
+
+# Set working directory
+WORKDIR /var/www/dmi-tcat
 
 #start apache and mysql
 CMD sudo service cron start && service mysql start && apachectl -D FOREGROUND

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ This Docker image uses a modified version of the installer (helpers/tcat-install
 - The `--progress=plain` tag ensure you can see all the output; important if your config file does not include passwords and they are auto generated.
 3. Run a container with the image:
 `docker container run --publish 80:80 --detach --name tcat tcat:1.0`
+4. In the future, you can stop and start your TCAT container with:
+`docker stop tcat`
+and
+`docker start tcat`
 
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -25,20 +25,21 @@ curl https://raw.githubusercontent.com/digitalmethodsinitiative/dmi-tcat/master/
 This Docker image uses a modified version of the installer (helpers/tcat-install-linux.sh) as a shortcut for easy deployment with docker.
 
 
-1. Add config in `./docker/config`
-2. build image:
-`docker image build -t tcat:1.0 .`
-3. run image:
+1. Add your Twitter token and key as well as any other needed information to the config file located here: `./docker/config`
+2. Build the image:
+`docker image build --progress=plain -t tcat:1.0 .`
+- The `--progress=plain` tag ensure you can see all the output; important if your config file does not include passwords and they are auto generated.
+3. Run a container with the image:
 `docker container run --publish 80:80 --detach --name tcat tcat:1.0`
 
 
 ## Issues
 
-Please use the issue templates when reporting issues and bugs. 
+Please use the issue templates when reporting issues and bugs.
 
 ## Status
 
-Nice way to describe the fact that we don't have much 
+Nice way to describe the fact that we don't have much
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ This Docker image uses a modified version of the installer (helpers/tcat-install
 
 
 1. Add your Twitter token and key as well as any other needed information to the config file located here: `./docker/config`
+```
+# Update at minimum
+CONSUMERKEY=
+CONSUMERSECRET=
+USERTOKEN=
+USERSECRET=
+```
 2. Build the image:
 `docker image build --progress=plain -t tcat:1.0 .`
 - The `--progress=plain` tag ensure you can see all the output; important if your config file does not include passwords and they are auto generated.

--- a/analysis/common/functions.php
+++ b/analysis/common/functions.php
@@ -1385,7 +1385,7 @@ function dataset_must_exist() {
     if (!isset($datasets[$dataset])) {
         http_response_code(404);
         header("Content-Type: text/plain");
-        echo "Error: unknown query bin: $dataset";
+        echo "Error: unknown query bin:" . htmlspecialchars($dataset);
         exit(0);
     }
 }

--- a/analysis/mod.sankeymaker.php
+++ b/analysis/mod.sankeymaker.php
@@ -67,14 +67,14 @@ require_once __DIR__ . '/common/Gexf.class.php';
 
         <form action="">
 
-            <input type="hidden" name="dataset" value="<?php echo $_GET["dataset"]; ?>" />
-            <input type="hidden" name="query" value="<?php echo $_GET["query"]; ?>" />
-            <input type="hidden" name="url_query" value="<?php echo $_GET["url_query"]; ?>" />
-            <input type="hidden" name="exclude" value="<?php echo $_GET["exclude"]; ?>" />
-            <input type="hidden" name="from_user_name" value="<?php echo $_GET["from_user_name"]; ?>" />
-            <input type="hidden" name="from_source" value="<?php echo $_GET["from_source"]; ?>" />
-            <input type="hidden" name="startdate" value="<?php echo $_GET["startdate"]; ?>" />
-            <input type="hidden" name="enddate" value="<?php echo $_GET["enddate"]; ?>" />
+            <input type="hidden" name="dataset" value="<?php echo htmlentities($_GET["dataset"]); ?>" />
+            <input type="hidden" name="query" value="<?php echo htmlentities($_GET["query"]); ?>" />
+            <input type="hidden" name="url_query" value="<?php echo htmlentities($_GET["url_query"]); ?>" />
+            <input type="hidden" name="exclude" value="<?php echo htmlentities($_GET["exclude"]); ?>" />
+            <input type="hidden" name="from_user_name" value="<?php echo htmlentities($_GET["from_user_name"]); ?>" />
+            <input type="hidden" name="from_source" value="<?php echo htmlentities($_GET["from_source"]); ?>" />
+            <input type="hidden" name="startdate" value="<?php echo htmlentities($_GET["startdate"]); ?>" />
+            <input type="hidden" name="enddate" value="<?php echo htmlentities($_GET["enddate"]); ?>" />
 
             <div class="form_row">
                 col1:
@@ -86,7 +86,7 @@ require_once __DIR__ . '/common/Gexf.class.php';
                     <option value="domain" <?php echo ($_GET["col1_type"] == "domain") ? "selected" : ""; ?>>domains</option>
                 </select>
 
-                cutoff (0 = all) <input name="col1_cutoff" value="<?php echo ($_GET["col1_cutoff"] == "") ? 0 : $_GET["col1_cutoff"]; ?>" />
+                cutoff (0 = all) <input name="col1_cutoff" value="<?php echo ($_GET["col1_cutoff"] == "") ? 0 : htmlentities($_GET["col1_cutoff"]); ?>" />
             </div>
 
             <div class="form_row">
@@ -99,7 +99,7 @@ require_once __DIR__ . '/common/Gexf.class.php';
                     <option value="domain" <?php echo ($_GET["col2_type"] == "domain") ? "selected" : ""; ?>>domains</option>
                 </select>
 
-                cutoff (0 = all) <input name="col2_cutoff" value="<?php echo ($_GET["col2_cutoff"] == "") ? 0 : $_GET["col2_cutoff"]; ?>" />
+                cutoff (0 = all) <input name="col2_cutoff" value="<?php echo ($_GET["col2_cutoff"] == "") ? 0 : htmlentities($_GET["col2_cutoff"]); ?>" />
             </div>
 
 
@@ -114,7 +114,7 @@ require_once __DIR__ . '/common/Gexf.class.php';
                     <option value="domain" <?php echo ($_GET["col3_type"] == "domain") ? "selected" : ""; ?>>domains</option>
                 </select>
 
-                cutoff (0 = all) <input name="col3_cutoff" value="<?php echo ($_GET["col3_cutoff"] == "") ? 0 : $_GET["col3_cutoff"]; ?>" />
+                cutoff (0 = all) <input name="col3_cutoff" value="<?php echo ($_GET["col3_cutoff"] == "") ? 0 : htmlentities($_GET["col3_cutoff"]); ?>" />
             </div>
 
 
@@ -129,6 +129,10 @@ require_once __DIR__ . '/common/Gexf.class.php';
 
 
         <?php
+        $dataset = htmlentities($dataset);
+        $col1_cutoff = htmlentities($_GET["col1_cutoff"]);
+        $col2_cutoff = htmlentities($_GET["col2_cutoff"]);
+        $col3_cutoff = htmlentities($_GET["col3_cutoff"]);
 
         validate_all_variables();
         dataset_must_exist();
@@ -153,11 +157,11 @@ require_once __DIR__ . '/common/Gexf.class.php';
 		$fulltweetcount = $data["count"];
 
 		// process colums
-		getFlow($_GET["col1_type"],$_GET["col1_cutoff"],$_GET["col2_type"],$_GET["col2_cutoff"],$_GET["discard_other"],0);
+		getFlow($_GET["col1_type"],$col1_cutoff,$_GET["col2_type"],$col2_cutoff,$_GET["discard_other"],0);
 
 		if($_GET["col3_type"] != "none") {
 
-			getFlow($_GET["col2_type"],$_GET["col2_cutoff"],$_GET["col3_type"],$_GET["col3_cutoff"],$_GET["discard_other"],1);
+			getFlow($_GET["col2_type"],$col2_cutoff,$_GET["col3_type"],$col3_cutoff,$_GET["discard_other"],1);
 		}
 
 

--- a/analysis/mod.sankeymaker.php
+++ b/analysis/mod.sankeymaker.php
@@ -129,7 +129,6 @@ require_once __DIR__ . '/common/Gexf.class.php';
 
 
         <?php
-        $dataset = htmlentities($dataset);
         $col1_cutoff = htmlentities($_GET["col1_cutoff"]);
         $col2_cutoff = htmlentities($_GET["col2_cutoff"]);
         $col3_cutoff = htmlentities($_GET["col3_cutoff"]);
@@ -207,7 +206,7 @@ require_once __DIR__ . '/common/Gexf.class.php';
 	        }
 
 			// voting for keeping the SQL output, nice way to trace results for expert users
-	        echo "sql query " . ($runcounter + 1) . ": " . $sql . "<br />";
+	        echo "sql query " . ($runcounter + 1) . ": " . htmlspecialchars($sql) . "<br />";
 
 	        // run through the data once to create item counts for cutting and fusing
 	        $data = array();

--- a/analysis/mod.trending.php
+++ b/analysis/mod.trending.php
@@ -28,7 +28,7 @@ validate_all_variables();
         <script type="text/javascript" src="https://www.google.com/jsapi"></script>
 
         <script type="text/javascript">
-     
+
             google.load("visualization", "1", {packages:["corechart"]});
         </script>
 
@@ -48,7 +48,7 @@ validate_all_variables();
                 <input type="hidden" name="startdate" value="<?php echo $startdate; ?>" />
                 <input type="hidden" name="enddate" value="<?php echo $enddate; ?>" />
                 <input type="hidden" name="interval" value="<?php echo $interval; ?>" />
-                <input type="hidden" name="customInterval" value="<?php if (isset($_GET['customInterval'])) echo $_GET['customInterval']; ?>" />
+                <input type="hidden" name="customInterval" value="<?php if (isset($_GET['customInterval'])) echo htmlentities($_GET['customInterval']); ?>" />
                 <tr>
                     <td>Keyword:</td>
                     <td><input type="text" name="query" value="<?php echo $query; ?>" /></td>
@@ -103,9 +103,9 @@ validate_all_variables();
                     <div style='clear:both'></div>
                     <div id="if_panel_linegraph_score" class="if_panel_box" ></div>
                     <script type="text/javascript">
-                                	
+
                         var data = new google.visualization.DataTable();
-                        data.addRows(<?php echo count($freq); ?>);                                                                          	
+                        data.addRows(<?php echo count($freq); ?>);
                         data.addColumn('string', 'Date');
                         data.addColumn('number', 'Tweets');
     <?php
@@ -118,9 +118,9 @@ validate_all_variables();
     ?>
         var chart = new google.visualization.LineChart(document.getElementById('if_panel_linegraph'));
         chart.draw(data, {width:1000, height:50, fontSize:9, hAxis:{slantedTextAngle:90, slantedText:true}, chartArea:{left:50,top:10,width:850,height:50}});
-                
+
         var data = new google.visualization.DataTable();
-        data.addRows(<?php echo count($freq); ?>);                                                                          	
+        data.addRows(<?php echo count($freq); ?>);
         data.addColumn('string', 'Date');
         data.addColumn('number', 'Score');
     <?php
@@ -137,7 +137,7 @@ validate_all_variables();
     ?>
         var chart = new google.visualization.LineChart(document.getElementById('if_panel_linegraph_score'));
         chart.draw(data, {width:1000, height:150, fontSize:9, hAxis:{slantedTextAngle:90, slantedText:true}, chartArea:{left:50,top:10,width:850,height:50}});
-                    </script>	
+                    </script>
                     <?php
                     print "<div style='clear:both'></div>";
                     print "<table><tr><th>date</th><th>frequency</th><th>score</th></tr>";

--- a/docker/config
+++ b/docker/config
@@ -1,0 +1,47 @@
+# TCAT Installer parameters
+
+# Convention for Boolean: 'y' true; all other values (e.g. blank or 'n') false
+
+# Twitter API credentials and capture options
+
+CONSUMERKEY=
+CONSUMERSECRET=
+USERTOKEN=
+USERSECRET=
+
+CAPTURE_MODE=1 # 1=track phrases/keywords, 2=follow users, 3=onepercent
+
+URLEXPANDYES=y # install URL Expander or not
+
+# Apache
+
+SERVERNAME= # should default to this machine's IP address (-s overrides)
+
+# TCAT
+TCAT_AUTO_UPDATE=0 # 0=off, 1=trivial, 2=substantial, 3=expensive
+
+# Unix user and group to own the TCAT files
+
+SHELLUSER=root
+SHELLGROUP=root
+
+# MySQL (blank password means randomly generate it)
+
+DBPASS= # password for the MySQL "root" administrator account
+
+TCATMYSQLUSER=tcatdbuser
+TCATMYSQLPASS=
+
+DB_CONFIG_MEMORY_PROFILE=y
+
+LETSENCRYPT=n
+
+# TCAT Web user interface logins (blank password means randomly generate it)
+
+TCATADMINUSER=admin
+TCATADMINPASS=
+
+TCATUSER=tcat
+TCATPASS=
+
+# End of TCAT installer parameters

--- a/helpers/tcat-install-linux.sh
+++ b/helpers/tcat-install-linux.sh
@@ -347,7 +347,7 @@ if [ "$DISTRIBUTION_ID" = 'Ubuntu' ]; then
 	echo "$PROG: error: unexpected Ubuntu version: $UBUNTU_VERSION" >&2
 	exit 1
     fi
-    if [ "$UBUNTU_VERSION" != '18.04' ] || [ "$UBUNTU_VERSION" != '20.04' ]; then
+    if [ "$UBUNTU_VERSION" != '18.04' ] && [ "$UBUNTU_VERSION" != '20.04' ]; then
 	if [ -z "$FORCE_INSTALL" ]; then
 	    echo "$PROG: error: unsupported distribution: Ubuntu $UBUNTU_VERSION" >&2
 	    exit 1

--- a/helpers/tcat-install-linux.sh
+++ b/helpers/tcat-install-linux.sh
@@ -347,7 +347,7 @@ if [ "$DISTRIBUTION_ID" = 'Ubuntu' ]; then
 	echo "$PROG: error: unexpected Ubuntu version: $UBUNTU_VERSION" >&2
 	exit 1
     fi
-    if [ "$UBUNTU_VERSION" != '18.04' ]; then
+    if [ "$UBUNTU_VERSION" != '18.04' ] || [ "$UBUNTU_VERSION" != '20.04' ]; then
 	if [ -z "$FORCE_INSTALL" ]; then
 	    echo "$PROG: error: unsupported distribution: Ubuntu $UBUNTU_VERSION" >&2
 	    exit 1


### PR DESCRIPTION
This is a simple fix that installs cron to the docker image which allows the controller.php to run. I also added a blank config that a user can just add their API credentials to. It should resolve [issue 433](https://github.com/digitalmethodsinitiative/dmi-tcat/issues/433) and I believe would have helped with [issue 417](https://github.com/digitalmethodsinitiative/dmi-tcat/issues/417).

Docker caveat: Data persists within the docker image, but if that image is rebuilt, it will be lost. You can thus stop and start the container with no issues and can run and update software within the container. But if we were to make any changes to the docker image that would require it to be rebuilt, collected data would not persist. 

The solution seems to be to use docker's volumes. I attempted a few ways to store the database in a volume, but could not get it to reliable persist after a rebuild. The best solution would likely be to have the database in it's own container, but that would require a bit more knowledge on how the rest of the application communicates with the database. Perhaps we can sit down and go through that at some point in the future.